### PR TITLE
Add "rank" abstract method

### DIFF
--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -37,3 +37,7 @@ class LateInteractionModel(ABC):
     @abstractmethod
     def _batch_search(self, name: str, queries: list[str]):
         ...
+
+    @abstractmethod
+    def rank(self, query: str, documents: list[str], k: int):
+        ...


### PR DESCRIPTION
Not claiming to be an expert here but could not run the re-rank function without the addition of this abstract method.  Please do correct me if I am wrong. I would love to hear from you @bclavie (especially if I am wrong so that I can learn)

My observation:
colbert.by inherits methods from base.py but there was no abstract method for the function rank which is used for re-ranking. Included that now.