### PR TITLE
Fix `train` docs + typo

### DIFF
--- a/ragatouille/RAGTrainer.py
+++ b/ragatouille/RAGTrainer.py
@@ -158,10 +158,11 @@ class RAGTrainer:
     ) -> str:
         """
         Launch training or fine-tuning of a ColBERT model.
+        
         Parameters:
             batch_size: int - Total batch size -- divice by n_usable_gpus for per-GPU batch size.
             nbits: int - number of bits used for vector compression by the traiened model. 2 is usually ideal.
-            maxsteps: int - End training early afte maxsteps steps.
+            maxsteps: int - End training early after maxsteps steps.
             use_ib_negatives: bool - Whether to use in-batch negatives to calculate loss or not.
             learning_rate: float - ColBERT litterature usually has this performing best between 3e-6 - 2e-5 depending on data size
             dim: int - Size of individual vector representations.


### PR DESCRIPTION
- `train()` docs have a broken format in the [API reference](https://ben.clavie.eu/ragatouille/api/#ragatouille.RAGTrainer.RAGTrainer.train) (I suspect is the missing new-line)
- also correcting a small typo

![Screenshot 2024-01-15 at 8 31 23 PM](https://github.com/bclavie/RAGatouille/assets/5973189/dae3b5b6-a4aa-4ad8-a10f-c09da7ce4892)
