### PR TITLE
Include metadata if present in retrieved documents.

### DIFF
--- a/ragatouille/integrations/_langchain.py
+++ b/ragatouille/integrations/_langchain.py
@@ -18,7 +18,12 @@ class RAGatouilleLangChainRetriever(BaseRetriever):
     ) -> List[Document]:
         """Get documents relevant to a query."""
         docs = self.model.search(query, **self.kwargs)
-        return [Document(page_content=doc["content"]) for doc in docs]
+        return [
+            Document(
+                page_content=doc["content"], metadata=doc.get("document_metadata", {})
+            )
+            for doc in docs
+        ]
 
 
 class RAGatouilleLangChainCompressor(BaseDocumentCompressor):


### PR DESCRIPTION
RAGatoulle now supports documents ids and metadata:
https://github.com/bclavie/RAGatouille?tab=readme-ov-file#%EF%B8%8F-indexing

Sadly when working as langchain retrievers as wrapper the metadata is missing.
This simple change include the metadata if present.

@bclavie 