### PR TITLE
Fix max_tokens float bug

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -563,7 +563,7 @@ class ColBERT(LateInteractionModel):
                     [len(x.split(" ")) for x in documents], 90
                 )
                 max_tokens = min(
-                    (math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1,
+                    math.floor((math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1),
                     512,
                 )
                 max_tokens = max(256, max_tokens)


### PR DESCRIPTION
According to https://github.com/bclavie/RAGatouille/issues/103 this issue is fixed, but I'm using RAGatouille==0.0.6b4 and the bug still seems to be happening for me. Maybe the fix is on a local branch somewhere and I'm just being impatient, if so feel free to close 😅.