### PR TITLE
Put encode prints behind verbose flag

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -690,9 +690,10 @@ class ColBERT(LateInteractionModel):
             dim=1,
         )
 
-        print("Shapes:")
-        print(f"encodings: {encodings.shape}")
-        print(f"doc_masks: {doc_masks.shape}")
+        if verbose:
+            print("Shapes:")
+            print(f"encodings: {encodings.shape}")
+            print(f"doc_masks: {doc_masks.shape}")
 
         if hasattr(self, "in_memory_collection"):
             if self.in_memory_metadata is not None:


### PR DESCRIPTION
Using Ragatouille in memory with the encode function and realized there was no way to prevent the log spam every time encode is called.

Just threw it behind the already existing (and default True) verbose flag.