### PR TITLE
Return 'chunk ids' (passage ids) to allow for deduplication

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -468,6 +468,7 @@ class ColBERT(LateInteractionModel):
                     "score": score,
                     "rank": rank - 1 if zero_index_ranks else rank,
                     "document_id": document_id,
+                    "passage_id": id_
                 }
 
                 if self.docid_metadata_map is not None:


### PR DESCRIPTION
This is to address issue #106. Will now return passage_id for all searches, which can be used for deduplication if needed.