### PR TITLE
RAGatouille: Dedicated ModelIndex

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -283,10 +283,7 @@ class ColBERT(LateInteractionModel):
         index_config["index_name"] = self.index_name
         # Ensure that the additional metadata we store does not collide with anything else.
         model_metadata["RAGatouille"] = {"index_config": index_config}  # type: ignore
-        self._write_collection_to_file(
-            model_metadata,
-            self.index_path + "/metadata.json",
-        )
+        srsly.write_json(self.index_path + "/metadata.json", model_metadata)
         self._write_collection_files_to_disk()
 
     def index(

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Literal, Optional, TypeVar, Union
 import numpy as np
 import srsly
 import torch
-from colbert import IndexUpdater, Searcher, Trainer
+from colbert import Trainer
 from colbert.infra import ColBERTConfig, Run, RunConfig
 from colbert.modeling.checkpoint import Checkpoint
 
@@ -154,7 +154,6 @@ class ColBERT(LateInteractionModel):
                     self._get_collection_files_from_disk(
                         str(Path(index_root) / self.index_name)
                     )
-            else: self.collection = []
 
         new_documents_with_ids = [
             {"content": doc, "document_id": new_pid_docid_map[pid]}

--- a/ragatouille/models/index.py
+++ b/ragatouille/models/index.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from time import time
-from typing import Any, List, Literal, Optional, TypeAlias, TypeVar, Union
+from typing import Any, List, Literal, Optional, TypeVar, Union
 
 from colbert import IndexUpdater, Indexer, Searcher
 from colbert.infra import ColBERTConfig
@@ -11,7 +11,7 @@ import torch
 import srsly
 
 
-IndexType: TypeAlias = Literal["FLAT", "HNSW", "PLAID"]
+IndexType = Literal["FLAT", "HNSW", "PLAID"]
 
 
 class ModelIndex(ABC):
@@ -156,6 +156,7 @@ class PLAIDModelIndex(ModelIndex):
         config: ColBERTConfig,
         verbose: bool = True,
     ) -> "PLAIDModelIndex":
+        _, _, _, _ = index_path, index_name, index_config, verbose
         return PLAIDModelIndex(config)
 
     def build(

--- a/ragatouille/models/index.py
+++ b/ragatouille/models/index.py
@@ -3,13 +3,10 @@ from pathlib import Path
 from time import time
 from typing import Any, List, Literal, Optional, TypeVar, Union
 
-from colbert import IndexUpdater, Indexer, Searcher
-from colbert.infra import ColBERTConfig
-
-import torch
-
 import srsly
-
+import torch
+from colbert import Indexer, IndexUpdater, Searcher
+from colbert.infra import ColBERTConfig
 
 IndexType = Literal["FLAT", "HNSW", "PLAID"]
 

--- a/ragatouille/models/index.py
+++ b/ragatouille/models/index.py
@@ -1,0 +1,213 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from time import time
+from typing import Any, List, Literal, Optional, TypeAlias, Union
+
+from colbert import Indexer
+from colbert.infra import ColBERTConfig
+
+import torch
+
+import srsly
+
+
+IndexType: TypeAlias = Literal["FLAT", "HNSW", "PLAID"]
+
+
+class ModelIndex(ABC):
+    index_type: IndexType
+
+    def __init__(
+        self,
+        config: ColBERTConfig,
+    ) -> None:
+        self.config = config
+
+    @staticmethod
+    @abstractmethod
+    def construct(
+        config: ColBERTConfig,
+        checkpoint: str,
+        collection: List[str],
+        index_name: Optional["str"] = None,
+        overwrite: Union[bool, str] = "reuse",
+        verbose: bool = True,
+        **kwargs,
+    ) -> "ModelIndex":
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def load_from_file(pretrained_model_path: Path) -> "ModelIndex":
+        ...
+
+    @abstractmethod
+    def build(self) -> None:
+        ...
+
+    @abstractmethod
+    def search(self) -> None:
+        ...
+
+    @abstractmethod
+    def batch_search(self) -> None:
+        ...
+
+    @abstractmethod
+    def add(self) -> None:
+        ...
+
+    @abstractmethod
+    def delete(self) -> None:
+        ...
+
+    @abstractmethod
+    def export(self) -> Optional[dict[str, Any]]:
+        ...
+
+
+class FLATModelIndex(ModelIndex):
+    index_type = "FLAT"
+
+
+class HNSWModelIndex(ModelIndex):
+    index_type = "HNSW"
+
+
+class PLAIDModelIndex(ModelIndex):
+    index_type = "PLAID"
+
+    def __init__(self, config: ColBERTConfig) -> None:
+        super().__init__(config)
+
+    @staticmethod
+    def construct(
+        config: ColBERTConfig,
+        checkpoint: Union[str, Path],
+        collection: List[str],
+        index_name: Optional["str"] = None,
+        overwrite: Union[bool, str] = "reuse",
+        verbose: bool = True,
+        **kwargs,
+    ) -> "PLAIDModelIndex":
+        bsize = kwargs.get("bsize", 32)
+        assert isinstance(bsize, int)
+
+        if torch.cuda.is_available():
+            import faiss
+
+            if not hasattr(faiss, "StandardGpuResources"):
+                print(
+                    "________________________________________________________________________________\n"
+                    "WARNING! You have a GPU available, but only `faiss-cpu` is currently installed.\n",
+                    "This means that indexing will be slow. To make use of your GPU.\n"
+                    "Please install `faiss-gpu` by running:\n"
+                    "pip uninstall --y faiss-cpu & pip install faiss-gpu\n",
+                    "________________________________________________________________________________",
+                )
+                print("Will continue with CPU indexing in 5 seconds...")
+                time.sleep(5)
+
+        nbits = 2
+        if len(collection) < 5000:
+            nbits = 8
+        elif len(collection) < 10000:
+            nbits = 4
+        config = ColBERTConfig.from_existing(
+            config, ColBERTConfig(nbits=nbits, index_bsize=bsize)
+        )
+
+        if len(collection) > 100000:
+            config.kmeans_niters = 4
+        elif len(collection) > 50000:
+            config.kmeans_niters = 10
+        else:
+            config.kmeans_niters = 20
+
+        # Instruct colbert-ai to disable forking if nranks == 1
+        config.avoid_fork_if_possible = True
+        indexer = Indexer(
+            checkpoint=checkpoint,
+            config=config,
+            verbose=verbose,
+        )
+        indexer.configure(avoid_fork_if_possible=True)
+        indexer.index(name=index_name, collection=collection, overwrite=overwrite)
+        return PLAIDModelIndex(config)
+
+    @staticmethod
+    def load_from_file(pretrained_model_path: Path) -> "PLAIDModelIndex":
+        raise NotImplementedError()
+
+    def build(self) -> None:
+        raise NotImplementedError()
+
+    def search(self) -> None:
+        raise NotImplementedError()
+
+    def batch_search(self) -> None:
+        raise NotImplementedError()
+
+    def add(self) -> None:
+        raise NotImplementedError()
+
+    def delete(self) -> None:
+        raise NotImplementedError()
+
+    def export(self) -> Optional[dict[str, Any]]:
+        raise NotImplementedError()
+
+
+class ModelIndexFactory:
+    _MODEL_INDEX_BY_NAME = {
+        "FLAT": FLATModelIndex,
+        "HNSW": HNSWModelIndex,
+        "PLAID": PLAIDModelIndex,
+    }
+
+    @staticmethod
+    def _raise_if_invalid_index_type(index_type: str) -> IndexType:
+        if index_type not in ["FLAT", "HNSW", "PLAID"]:
+            raise ValueError(
+                f"Unsupported index_type `{index_type}`; it must be one of 'FLAT', 'HNSW', OR 'PLAID'"
+            )
+        return index_type  # type: ignore
+
+    @staticmethod
+    def construct(
+        index_type: Union[Literal["auto"], IndexType],
+        config: ColBERTConfig,
+        checkpoint: str,
+        collection: List[str],
+        index_name: Optional["str"] = None,
+        overwrite: Union[bool, str] = "reuse",
+        verbose: bool = True,
+        **kwargs,
+    ) -> ModelIndex:
+        # Automatically choose the appropriate index for the desired "workload".
+        if index_type == "auto":
+            # NOTE: For now only PLAID indexes are supported.
+            index_type = "PLAID"
+        return ModelIndexFactory._MODEL_INDEX_BY_NAME[
+            ModelIndexFactory._raise_if_invalid_index_type(index_type)
+        ].construct(
+            config, checkpoint, collection, index_name, overwrite, verbose, **kwargs
+        )
+
+    @staticmethod
+    def _file_index_type(pretrained_model_path: Path) -> IndexType:
+        try:
+            index_type = srsly.read_json(str(pretrained_model_path / "metadata.json"))[
+                "index_type"
+            ]
+            assert isinstance(index_type, str)
+        except KeyError:
+            index_type = "PLAID"
+        return ModelIndexFactory._raise_if_invalid_index_type(index_type)
+
+    @staticmethod
+    def load_from_file(pretrained_model_path: Path) -> ModelIndex:
+        index_type = ModelIndexFactory._file_index_type(pretrained_model_path)
+        return ModelIndexFactory._MODEL_INDEX_BY_NAME[index_type].load_from_file(
+            pretrained_model_path
+        )


### PR DESCRIPTION
Starts to decouple a concrete `ModelIndex` from the `LateInteractionModel`.
The aim here is to be able to support a variety of different Indexes in the future (e.g., flat, or HNSW).
In particular, it should be possible to support lower depdenceny/CRUD-friendly indices in case of a small number of documents.

- In case the concept looks good, I can proceed to move more functionality from the Model to the Index.
- Once PLAID Indexes are supported, it should be rather straight-forward to add support for lower dependency indexes.

Relevant issue: #110