### PR TITLE
update collection when adding to index

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -214,6 +214,10 @@ class ColBERT(LateInteractionModel):
             updater.add([doc["content"] for doc in new_documents_with_ids])
             updater.persist_to_disk()
 
+            self.collection = self.collection + [
+                doc["content"] for doc in new_documents_with_ids
+            ]
+
             self._write_collection_files_to_disk()
 
         print(


### PR DESCRIPTION
Currently, when I run the following script:

```
from ragatouille import RAGPretrainedModel

def main():
    RAG = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")

    documents = [f"fake document {i}" for i in range(5000)]

    # Add documents to the index
    RAG.index(
        collection=documents,
        index_name="demo",
    )

    results1 = RAG.search(query="sfeqsbsrfgb {i}", k=3)
    print("RESULTS 1", results1)

    new_documents = [f"sfeqsbsrfgb {i}" for i in range(1)]
    RAG.add_to_index(new_documents)

    results2 = RAG.search(query="sfeqsbsrfgb", k=3)
    print("RESULTS 2", results2)

    RAG2 = RAGPretrainedModel.from_index(".ragatouille/colbert/indexes/demo/")
    results3 = RAG2.search(query="sfeqsbsrfgb", k=3)
    print("RESULTS 3", results3)

if __name__ == "__main__":
    main()
```

I get this error:
```
Traceback (most recent call last):
  File "/Users/ksadov/Documents/RAGatouille/test_add.py", line 19, in <module>
    results2 = RAG2.search(query="sfeqsbsrfgb 9", k=3)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ksadov/Documents/RAGatouille/ragatouille/RAGPretrainedModel.py", line 311, in search
    return self.model.search(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/ksadov/Documents/RAGatouille/ragatouille/models/colbert.py", line 485, in search
    "content": self.collection[id_],
               ~~~~~~~~~~~~~~~^^^^^
IndexError: list index out of range
```

This seems to be because RAG.model.collection isn't actually updated before the `_write_collection_files_to_disk()` call. My proposed fix makes this update.

As an aside: after the fix, the above code produces different values for results2 and results3, which makes me think that add_to_index isn't properly updating the searcher or something-- it seems like I should be able to search for documents after adding them to the index without having to read from disk?