### PR TITLE
fix: fix inversion method & pytorch Kmeans OOM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "RAGatouille"
-version = "0.0.8post1"
+version = "0.0.8post2"
 description = "Library to facilitate the use of state-of-the-art retrieval models in common RAG contexts."
 authors = ["Benjamin Clavie <ben@clavie.eu>"]
 license = "Apache-2.0"

--- a/ragatouille/__init__.py
+++ b/ragatouille/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.8post1"
+__version__ = "0.0.8post2"
 from .RAGPretrainedModel import RAGPretrainedModel
 from .RAGTrainer import RAGTrainer
 

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -92,8 +92,11 @@ class ColBERT(LateInteractionModel):
         self.run_context.__enter__()  # Manually enter the context
         self.searcher = None
 
-    def _invert_pid_docid_map(self) -> Dict[str, int]:
-        return {v: k for k, v in self.pid_docid_map.items()}
+    def _invert_pid_docid_map(self) -> Dict[str, List[int]]:
+        d = defaultdict(list)
+        for k, v in self.pid_docid_map.items():
+            d[v].append(k)
+        return d
 
     def _get_collection_files_from_disk(self, index_path: str):
         self.collection = srsly.read_json(index_path / "collection.json")

--- a/ragatouille/models/index.py
+++ b/ragatouille/models/index.py
@@ -1,7 +1,7 @@
+import time
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from pathlib import Path
-import time
 from typing import Any, List, Literal, Optional, TypeVar, Union
 
 import srsly

--- a/ragatouille/models/index.py
+++ b/ragatouille/models/index.py
@@ -195,7 +195,7 @@ class PLAIDModelIndex(ModelIndex):
 
         # Monkey-patch colbert-ai to avoid using FAISS
         monkey_patching = (
-            len(collection) < 100000 and kwargs.get("use_faiss", False) is False
+            len(collection) < 75000 and kwargs.get("use_faiss", False) is False
         )
         if monkey_patching:
             print(


### PR DESCRIPTION
- Fix an issue where the doc_id -> pid map was 1:1 instead of 1:many
- Lower the threshold to monkey patch the CollectionEncoder to use PyTorch k-means to 75000 documents to avoid OOMs due to poor memory usage of the pytorch kmeans implementation.