### PR TITLE
Add multi index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:        ## Install the package and dependencies in a venv
 	uv pip install -e .[api]
 
 run-api:        ## Run the api server
-	uv run python -m ragatouille.server.server --index_name .ragatouille/colbert/indexes/demo --reload
+	uv run python -m ragatouille.server.server --index-root  /Users/pau/development/taizen-rag/.ragatouille --experiment-name colbert --reload
 
 lint:   ## Run linters: ruff
 	uv run ruff check . --fix

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help install clean update-deps setup-uv
+
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+PYTHON_VERSION ?= 3.12
+
+help:   ## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+install:        ## Install the package and dependencies in a venv
+	uv venv --python  $(PYTHON_VERSION)
+	uv pip install -e .[api]
+
+run-api:        ## Run the api server
+	uv run python -m ragatouille.server.server --index_name .ragatouille/colbert/indexes/demo --reload
+
+lint:   ## Run linters: ruff
+	uv run ruff check . --fix
+
+clean:  ## Clean up build artifacts.
+	find . -name '__pycache__' -exec rm -rf {} +
+	find . -name '*.pyc' -exec rm -rf {} +
+	rm -rf .pytest_cache
+	rm -rf .mypy_cache
+	rm -rf .ruff_cache
+	rm -rf dist
+	rm -rf build
+	rm -rf .venv
+
+update-deps:    ## Update dependencies.
+	uv pip compile pyproject.toml -o requirements.txt
+	uv pip sync requirements.txt
+	uv run pre-commit autoupdate
+
+setup-uv:   ## Setup uv with the specified version
+	curl -LsSf https://astral.sh/uv/install.sh | sh -s

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+This is a fork of RAGatouille, a wrapper over Colbert-AI which provides a straightforward API.
+
+Right now to adapt it to Taizen use we need:
+ 1. We need an index by project_id. Right now each index is associated to a model instance, so this can clutter memory pretty quick. We need to change something so the model is loaded 1 time and each index is stored in memory.
+ 2. For the full workflow: The API workers would need to spin up a task. With only 1 worker we would then perform the search or index. (Maybe, since the worker is spinned up with parameters we can pass that to the worker and let each worker instantiate the index itself)
+ 3. We can wrap up the endpoints with batched for a better use of parallel resources. We have to be careful because requests would have to be split by project_id...
+ 4. Right now each index has to be manually created, we should provide an endpoint for that.

--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,7 @@ Right now to adapt it to Taizen use we need:
  2. For the full workflow: The API workers would need to spin up a task. With only 1 worker we would then perform the search or index. (Maybe, since the worker is spinned up with parameters we can pass that to the worker and let each worker instantiate the index itself)
  3. We can wrap up the endpoints with batched for a better use of parallel resources. We have to be careful because requests would have to be split by project_id...
  4. Right now each index has to be manually created, we should provide an endpoint for that.
+
+ For training, remember:
+    # Jina uses query_prefix="[QueryMarker]"
+    # Jine uses document_prefix="[DocumentMarker]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools"] 
-build-backend = "setuptools.build_meta" 
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = [
@@ -12,50 +12,47 @@ packages = [
 ]
 
 [project]
-name = "RAGatouille" 
+name = "RAGatouille"
 version = "0.0.9post2"
 description = "Library to facilitate the use of state-of-the-art retrieval models in common RAG contexts."
 keywords = ["reranking", "retrieval", "rag", "nlp"]
-authors = [
-  {name = "Ben Clavié", email = "bc@answer.ai" }
-]
-maintainers = [
-  {name = "Ben Clavié", email = "bc@answer.ai" }
-]
-license = {file = "LICENSE"}
+authors = [{ name = "Ben Clavié", email = "bc@answer.ai" }]
+maintainers = [{ name = "Ben Clavié", email = "bc@answer.ai" }]
+license = { file = "LICENSE" }
 readme = "README.md"
+requires-python = "~=3.12.0"
 
 dependencies = [
-  "llama-index",
-  "faiss-cpu",
-  "langchain_core",
-  "colbert-ai>=0.2.19",
-  "langchain",
-  "onnx",
-  "srsly",
-  "voyager",
-  "torch>=1.13",
-  "fast-pytorch-kmeans",
-  "sentence-transformers",
+    "llama-index",
+    "faiss-cpu",
+    "colbert-ai @ git+https://github.com/stanford-futuredata/ColBERT.git",
+    "onnx",
+    "srsly",
+    "voyager",
+    "torch>=1.13",
+    "fast-pytorch-kmeans",
+    "sentence-transformers",
+    "setuptools",
+    "einops",
+    "psutil"
 ]
 
 [project.optional-dependencies]
 all = [
     "llama-index",
-    "langchain",
     "rerankers",
     "voyager",
+    "fastapi >= 0.114.1",
+    "uvicorn >= 0.30.6",
+    "batched >= 0.1.2",
 ]
-llamaindex = ["llama-index"]
-langchain = ["langchain"]
+api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
 train = ["sentence-transformers", "pylate", "rerankers"]
 
 [project.urls]
 "Homepage" = "https://github.com/answerdotai/ragatouille"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-    "ignore::Warning"
-]
+filterwarnings = ["ignore::Warning"]
 
-target-version = "py39"
+target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "sentence-transformers",
     "setuptools",
     "einops",
-    "psutil"
+    "psutil",
+    "pytest>=8.4.0",
 ]
 
 [project.optional-dependencies]
@@ -45,8 +46,9 @@ all = [
     "fastapi >= 0.114.1",
     "uvicorn >= 0.30.6",
     "batched >= 0.1.2",
+    "pytest"
 ]
-api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2"]
+api = ["fastapi >= 0.114.1", "uvicorn >= 0.30.6", "batched >= 0.1.2", "pytest"]
 train = ["sentence-transformers", "pylate", "rerankers"]
 
 [project.urls]

--- a/ragatouille/RAGPretrainedModel.py
+++ b/ragatouille/RAGPretrainedModel.py
@@ -2,15 +2,15 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
-from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
-from langchain_core.retrievers import BaseRetriever
+#from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
+#from langchain_core.retrievers import BaseRetriever
 
 from ragatouille.data.corpus_processor import CorpusProcessor
 from ragatouille.data.preprocessors import llama_index_sentence_splitter
-from ragatouille.integrations import (
-    RAGatouilleLangChainCompressor,
-    RAGatouilleLangChainRetriever,
-)
+#from ragatouille.integrations import (
+#    RAGatouilleLangChainCompressor,
+#    RAGatouilleLangChainRetriever,
+#)
 from ragatouille.models import ColBERT, LateInteractionModel
 
 
@@ -413,10 +413,10 @@ class RAGPretrainedModel:
         """
         self.model.clear_encoded_docs(force=force)
 
-    def as_langchain_retriever(self, **kwargs: Any) -> BaseRetriever:
-        return RAGatouilleLangChainRetriever(model=self, kwargs=kwargs)
+    #def as_langchain_retriever(self, **kwargs: Any) -> BaseRetriever:
+    #    return RAGatouilleLangChainRetriever(model=self, kwargs=kwargs)
 
-    def as_langchain_document_compressor(
-        self, k: int = 5, **kwargs: Any
-    ) -> BaseDocumentCompressor:
-        return RAGatouilleLangChainCompressor(model=self, k=k, kwargs=kwargs)
+    #def as_langchain_document_compressor(
+    #    self, k: int = 5, **kwargs: Any
+    #) -> BaseDocumentCompressor:
+    #    return RAGatouilleLangChainCompressor(model=self, k=k, kwargs=kwargs)

--- a/ragatouille/data/preprocessors.py
+++ b/ragatouille/data/preprocessors.py
@@ -9,6 +9,7 @@ except ImportError:
 def llama_index_sentence_splitter(
     documents: list[str], document_ids: list[str], chunk_size=256
 ):
+    #raise NotImplementedError("Llama index is needed to execute this function")
     chunk_overlap = min(chunk_size / 4, min(chunk_size / 2, 64))
     chunks = []
     node_parser = SentenceSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)

--- a/ragatouille/integrations/_langchain.py
+++ b/ragatouille/integrations/_langchain.py
@@ -1,60 +1,62 @@
 from typing import Any, List, Optional, Sequence
 
-from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
-from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun, Callbacks
-from langchain_core.documents import Document
-from langchain_core.retrievers import BaseRetriever
+#from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
+#from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun, Callbacks
+#from langchain_core.documents import Document
+#from langchain_core.retrievers import BaseRetriever
 
 
-class RAGatouilleLangChainRetriever(BaseRetriever):
-    model: Any
-    kwargs: dict = {}
+class RAGatouilleLangChainRetriever():
+    pass
+    #model: Any
+    #kwargs: dict = {}
 
-    def _get_relevant_documents(
-        self,
-        query: str,
-        *,
-        run_manager: CallbackManagerForRetrieverRun,  # noqa
-    ) -> List[Document]:
-        """Get documents relevant to a query."""
-        docs = self.model.search(query, **self.kwargs)
-        return [
-            Document(
-                page_content=doc["content"], metadata=doc.get("document_metadata", {})
-            )
-            for doc in docs
-        ]
+    #def _get_relevant_documents(
+    #    self,
+    #    query: str,
+    #    *,
+    #    run_manager: CallbackManagerForRetrieverRun,  # noqa
+    #) -> List[Document]:
+    #    """Get documents relevant to a query."""
+    #    docs = self.model.search(query, **self.kwargs)
+    #    return [
+    #        Document(
+    #            page_content=doc["content"], metadata=doc.get("document_metadata", {})
+    #        )
+    #        for doc in docs
+    #    ]
 
 
-class RAGatouilleLangChainCompressor(BaseDocumentCompressor):
-    model: Any
-    kwargs: dict = {}
-    k: int = 5
+class RAGatouilleLangChainCompressor():
+    pass
+    #model: Any
+    #kwargs: dict = {}
+    #k: int = 5
 
-    class Config:
-        """Configuration for this pydantic object."""
+    #class Config:
+    #    """Configuration for this pydantic object."""
 
-        arbitrary_types_allowed = True
+    #    arbitrary_types_allowed = True
 
-    def compress_documents(
-        self,
-        documents: Sequence[Document],
-        query: str,
-        callbacks: Optional[Callbacks] = None,  # noqa
-        **kwargs,
-    ) -> Any:
-        """Rerank a list of documents relevant to a query."""
-        doc_list = list(documents)
-        _docs = [d.page_content for d in doc_list]
-        results = self.model.rerank(
-            query=query,
-            documents=_docs,
-            k=kwargs.get("k", self.k),
-            **self.kwargs,
-        )
-        final_results = []
-        for r in results:
-            doc = doc_list[r["result_index"]]
-            doc.metadata["relevance_score"] = r["score"]
-            final_results.append(doc)
-        return final_results
+    #def compress_documents(
+    #    self,
+    #    documents: Sequence[Document],
+    #    query: str,
+    #    callbacks: Optional[Callbacks] = None,  # noqa
+    #    **kwargs,
+    #) -> Any:
+    #    """Rerank a list of documents relevant to a query."""
+    #    doc_list = list(documents)
+    #    _docs = [d.page_content for d in doc_list]
+    #    results = self.model.rerank(
+    #        query=query,
+    #        documents=_docs,
+    #        k=kwargs.get("k", self.k),
+    #        **self.kwargs,
+    #    )
+    #    final_results = []
+    #    for r in results:
+    #        doc = doc_list[r["result_index"]]
+    #        doc.metadata["relevance_score"] = r["score"]
+    #        final_results.append(doc)
+    #    return final_results

--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Union
+from typing import Union, List, Optional, Dict, Any, Literal
 
 
 class LateInteractionModel(ABC):
@@ -8,30 +8,220 @@ class LateInteractionModel(ABC):
     def __init__(
         self,
         pretrained_model_name_or_path: Union[str, Path],
-        n_gpu,
+        index_root: Optional[str] = None,
+        n_gpu: int = -1,
+        verbose: int = 1,
+        initial_index_name: Optional[str] = None,
+        experiment_name: str = "colbert",
+        **kwargs: Any,
     ):
+        """
+        Initializes the late-interaction model.
+
+        Parameters:
+            pretrained_model_name_or_path: Path to a local checkpoint or Hugging Face model name.
+            index_root: The root directory where all named indices will be stored/loaded from.
+            n_gpu: Number of GPUs to use. -1 for all available.
+            verbose: Verbosity level.
+            initial_index_name: Optionally, the name of an index to load immediately.
+            experiment_name: Name of the experiment, used in structuring the index path.
+            **kwargs: Additional keyword arguments for model configuration.
+        """
         ...
 
     @abstractmethod
-    def train():
+    def index(
+        self,
+        index_name: str,
+        collection: List[str],
+        pid_docid_map: Dict[int, str],
+        docid_metadata_map: Optional[Dict[str, Any]] = None,
+        max_document_length: int = 256,
+        overwrite: Union[bool, str] = "reuse",
+        bsize: int = 32,
+        use_faiss: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """
+        Builds or updates an index for the given collection of passages.
+
+        Parameters:
+            index_name: The name of the index to build or update.
+            collection: List of passages/chunks to index.
+            pid_docid_map: Mapping from passage ID (0-indexed within collection) to original document ID.
+            docid_metadata_map: Optional mapping from original document ID to its metadata.
+            max_document_length: Maximum document length for configuring the index (e.g., doc_maxlen).
+            overwrite: Policy for overwriting if index exists.
+            bsize: Batch size for encoding passages.
+            use_faiss: Whether to use FAISS for the index backend (if applicable).
+            **kwargs: Additional keyword arguments for index-specific configuration.
+
+        Returns:
+            The path to the created or updated index.
+        """
         ...
 
     @abstractmethod
-    def index(self, name: str, collection: list[str]):
+    def add_to_index(
+        self,
+        index_name: str,
+        new_documents: List[str],
+        new_pid_docid_map_for_new_docs: Dict[int, str],
+        new_docid_metadata_map: Optional[Dict[str, Any]] = None,
+        bsize: int = 32,
+        use_faiss: bool = False,
+    ) -> None:
+        """
+        Adds new passages to an existing index.
+
+        Parameters:
+            index_name: The name of the index to add to.
+            new_documents: List of new passages/chunks to add.
+            new_pid_docid_map_for_new_docs: Mapping for the new passages (0-indexed for new_documents)
+                                             to their original document IDs.
+            new_docid_metadata_map: Optional metadata for original document IDs corresponding to new_documents.
+            bsize: Batch size for encoding new passages.
+            use_faiss: Whether to use FAISS if the add operation triggers a rebuild.
+        """
         ...
 
     @abstractmethod
-    def add_to_index(self):
+    def delete_from_index(
+        self,
+        index_name: str,
+        document_ids: Union[str, List[str]],
+    ) -> None:
+        """
+        Deletes documents (and all their associated passages) from a specified index.
+
+        Parameters:
+            index_name: The name of the index from which to delete.
+            document_ids: A single original document ID or a list of original document IDs to delete.
+        """
         ...
 
     @abstractmethod
-    def search(self, name: str, query: Union[str, list[str]]):
+    def search(
+        self,
+        index_name: str,
+        query: Union[str, List[str]],
+        k: int = 10,
+        force_fast: bool = False,
+        zero_index_ranks: bool = False,
+        doc_ids: Optional[List[str]] = None,
+    ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
+        """
+        Searches an index for a given query or list of queries.
+
+        Parameters:
+            index_name: The name of the index to search.
+            query: The query string or list of query strings.
+            k: The number of results to return per query.
+            force_fast: Use faster, potentially less accurate search settings.
+            zero_index_ranks: If True, ranks are 0-indexed. Otherwise 1-indexed.
+            doc_ids: Optional list of original document IDs to restrict the search to.
+
+        Returns:
+            A list of result dictionaries for a single query, or a list of lists of
+            result dictionaries for multiple queries.
+        """
         ...
 
     @abstractmethod
-    def _search(self, name: str, query: str):
+    def train(
+        self,
+        index_name_for_config: Optional[str],
+        data_dir: Union[str, Path],
+        training_config_overrides: Dict[str, Any],
+    ) -> str:
+        """
+        Trains the model.
+
+        Parameters:
+            index_name_for_config: Optional name of an existing index to use its configuration as a base.
+            data_dir: Path to the directory containing training data (triples, queries, corpus).
+            training_config_overrides: Dictionary of parameters to override in the model's training configuration.
+
+        Returns:
+            Path to the best trained checkpoint.
+        """
         ...
 
     @abstractmethod
-    def _batch_search(self, name: str, queries: list[str]):
+    def rank(
+        self,
+        query: str,
+        documents: List[str],
+        k: int = 10,
+        zero_index_ranks: bool = False,
+        bsize: Union[Literal["auto"], int] = "auto",
+        max_tokens: Union[Literal["auto"], int] = "auto",
+    ) -> List[Dict[str, Any]]:
+        """
+        Reranks a list of documents in-memory for a given query without using a disk-based index.
+
+        Parameters:
+            query: The query string.
+            documents: A list of document contents (passages) to rerank.
+            k: The number of top documents to return.
+            zero_index_ranks: If True, ranks are 0-indexed.
+            bsize: Batch size for encoding.
+            max_tokens: Max tokens for document encoding. 'auto' adjusts based on content.
+
+        Returns:
+            A list of reranked result dictionaries.
+        """
+        ...
+
+    @abstractmethod
+    def encode(
+        self,
+        documents: List[str],
+        document_metadatas: Optional[List[Optional[Dict[str, Any]]]] = None,
+        bsize: int = 32,
+        max_tokens: Union[Literal["auto"], int] = "auto",
+        verbose_override: Optional[bool] = None,
+    ) -> None:
+        """
+        Encodes documents and caches their embeddings in memory.
+
+        Parameters:
+            documents: List of document contents to encode.
+            document_metadatas: Optional list of metadata dicts, matched to documents.
+            bsize: Batch size for encoding.
+            max_tokens: Max tokens for document encoding. 'auto' adjusts based on content.
+            verbose_override: Override instance verbosity for this call.
+        """
+        ...
+
+    @abstractmethod
+    def search_encoded_docs(
+        self,
+        queries: Union[str, List[str]],
+        k: int = 10,
+        bsize: int = 32,
+        zero_index_ranks: bool = False,
+    ) -> Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]:
+        """
+        Searches through documents previously encoded and cached in memory via `encode()`.
+
+        Parameters:
+            queries: The query string or list of query strings.
+            k: The number of results to return per query.
+            bsize: Batch size for query encoding.
+            zero_index_ranks: If True, ranks are 0-indexed.
+
+        Returns:
+            Search results, similar to the `search` method for indexed data.
+        """
+        ...
+
+    @abstractmethod
+    def clear_encoded_docs(self, force: bool = False) -> None:
+        """
+        Clears any documents and their embeddings cached in memory by `encode()`.
+
+        Parameters:
+            force: If True, clears without a confirmation delay.
+        """
         ...

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -3,7 +3,7 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, TypeVar, Union
+from typing import Dict, List, Literal, Optional, TypeVar, Union, Any
 
 import numpy as np
 import srsly
@@ -22,439 +22,618 @@ class ColBERT(LateInteractionModel):
     def __init__(
         self,
         pretrained_model_name_or_path: Union[str, Path],
-        n_gpu: int = -1,
-        index_name: Optional[str] = None,
-        verbose: int = 1,
-        load_from_index: bool = False,
-        training_mode: bool = False,
         index_root: Optional[str] = None,
-        **kwargs,
+        n_gpu: int = -1,
+        verbose: int = 1,
+        initial_index_name: Optional[str] = None,
+        experiment_name: str = "colbert", # Default experiment name
+        **kwargs, # Catch-all for other ColBERTConfig settings for new indices
     ):
         self.verbose = verbose
-        self.collection = None
-        self.pid_docid_map = None
-        self.docid_pid_map = None
-        self.docid_metadata_map = None
-        self.base_model_max_tokens = 510
+        self.base_pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.index_root = index_root if index_root is not None else ".ragatouille/"
+        self.experiment_name = experiment_name
+
+        self.base_model_max_tokens = 510 # Default, will be updated after model load
+
         if n_gpu == -1:
             n_gpu = 1 if torch.cuda.device_count() == 0 else torch.cuda.device_count()
 
-        self.loaded_from_index = load_from_index
+        # Multi-index storage
+        self.collections: Dict[str, List[str]] = {}
+        self.pid_docid_maps: Dict[str, Dict[int, str]] = {}
+        self.docid_pid_maps: Dict[str, Dict[str, List[int]]] = {}
+        self.docid_metadata_maps: Dict[str, Optional[Dict[str, Any]]] = {}
+        self.model_indices: Dict[str, Optional[ModelIndex]] = {}
+        self.index_configs: Dict[str, ColBERTConfig] = {} # Stores specific config for each index
+        self.index_paths: Dict[str, str] = {} # Stores full path to each index directory
 
-        self.model_index: Optional[ModelIndex] = None
-        if load_from_index:
-            self.index_path = str(pretrained_model_name_or_path)
-            ckpt_config = ColBERTConfig.load_from_index(
-                str(pretrained_model_name_or_path)
-            )
-            self.model_index = ModelIndexFactory.load_from_file(
-                self.index_path, index_name, ckpt_config
-            )
-            self.config = self.model_index.config
-            self.run_config = RunConfig(
-                nranks=n_gpu, experiment=self.config.experiment, root=self.config.root
-            )
-            split_root = str(pretrained_model_name_or_path).split("/")[:-1]
-            self.config.root = "/".join(split_root)
-            self.index_root = self.config.root
-            self.checkpoint = self.config.checkpoint
-            self.index_name = self.config.index_name
-            self._get_collection_files_from_disk(pretrained_model_name_or_path)
-            # TODO: Modify root assignment when loading from HF
+        # Load base model configuration
+        # For new indices, this base_config will be the starting point
+        self.base_model_config = ColBERTConfig.load_from_checkpoint(
+            str(pretrained_model_name_or_path),
+            **kwargs # Pass other ColBERTConfig settings
+        )
+        self.base_model_config.root = str(Path(self.index_root) / self.experiment_name / "indexes")
+        self.base_model_config.experiment = self.experiment_name
 
-        else:
-            self.index_root = index_root if index_root is not None else ".ragatouille/"
-            ckpt_config = ColBERTConfig.load_from_checkpoint(
-                str(pretrained_model_name_or_path)
-            )
-            self.run_config = RunConfig(
-                nranks=n_gpu, experiment="colbert", root=self.index_root
-            )
-            local_config = ColBERTConfig(**kwargs)
-            self.config = ColBERTConfig.from_existing(
-                ckpt_config,
-                local_config,
-            )
-            self.checkpoint = pretrained_model_name_or_path
-            self.index_name = index_name
-            self.config.experiment = "colbert"
-            self.config.root = self.index_root
 
-        if not training_mode:
-            self.inference_ckpt = Checkpoint(
-                self.checkpoint, colbert_config=self.config
-            )
-            self.base_model_max_tokens = (
-                self.inference_ckpt.bert.config.max_position_embeddings
-            ) - 4
+        # Global RunConfig for the underlying ColBERT model
+        self.run_config = RunConfig(
+            nranks=n_gpu, experiment=self.experiment_name, root=self.index_root
+        )
+
+        # Load the actual inference model weights (once)
+        self.inference_ckpt = Checkpoint(
+            str(self.base_pretrained_model_name_or_path), colbert_config=self.base_model_config
+        )
+        self.base_model_max_tokens = (
+            self.inference_ckpt.bert.config.max_position_embeddings
+        ) - 4 # Standard adjustment
 
         self.run_context = Run().context(self.run_config)
         self.run_context.__enter__()  # Manually enter the context
-        self.searcher = None
 
-    def _invert_pid_docid_map(self) -> Dict[str, List[int]]:
+        if initial_index_name:
+            if not self.index_root:
+                raise ValueError("index_root must be provided if initial_index_name is set.")
+            try:
+                self._get_or_load_index_context(initial_index_name, create_if_not_exists=False)
+                if self.verbose > 0:
+                    print(f"Successfully loaded initial index '{initial_index_name}'.")
+            except FileNotFoundError:
+                if self.verbose > 0:
+                    print(f"Initial index '{initial_index_name}' not found at expected location. It will need to be created via .index() method.")
+            except Exception as e:
+                if self.verbose > 0:
+                    print(f"Failed to load initial index '{initial_index_name}': {e}")
+
+
+    def _get_index_path(self, index_name: str) -> str:
+        return str(
+            Path(self.index_root)
+            / Path(self.experiment_name)
+            / "indexes"
+            / index_name
+        )
+
+    def _get_or_load_index_context(self, index_name: str, create_if_not_exists: bool = False, config_overrides: Optional[Dict[str, Any]] = None) -> ColBERTConfig:
+        if index_name in self.index_configs:
+            return self.index_configs[index_name]
+
+        current_index_path = self._get_index_path(index_name)
+        self.index_paths[index_name] = current_index_path
+
+        # Determine the root for this specific index's config
+        # This root is where ColBERT will look for subdirectories like `plan/` or `ivf/` for the index
+        specific_index_config_root = str(Path(self.index_root) / self.experiment_name / "indexes")
+
+        if os.path.exists(Path(current_index_path) / "metadata.json"):
+            # Index exists, load its specific configuration and data
+            if self.verbose > 0:
+                print(f"Loading existing index context for '{index_name}' from {current_index_path}")
+
+            # Load the ColBERTConfig specific to this index from its metadata.json
+            # This config might have different `doc_maxlen`, `nbits`, etc.
+            loaded_config = ColBERTConfig.load_from_index(current_index_path)
+
+            # Ensure its root and experiment are set correctly for operations
+            loaded_config.root = specific_index_config_root
+            loaded_config.experiment = self.experiment_name
+            loaded_config.index_name = index_name # Ensure index_name is part of its config
+
+            self.index_configs[index_name] = loaded_config
+
+            self.model_indices[index_name] = ModelIndexFactory.load_from_file(
+                current_index_path, index_name, loaded_config, verbose=self.verbose > 0
+            )
+            self._get_collection_files_from_disk(index_name, current_index_path)
+            return loaded_config
+        elif create_if_not_exists:
+            if self.verbose > 0:
+                print(f"Creating new index context for '{index_name}' at {current_index_path}")
+            # Index does not exist, create new context (typically during .index() call)
+            # Start with a copy of the base model config, then apply overrides
+            new_config = ColBERTConfig.from_existing(self.base_model_config, ColBERTConfig(**(config_overrides or {})))
+            new_config.root = specific_index_config_root
+            new_config.experiment = self.experiment_name
+            new_config.index_name = index_name # Important for operations
+
+            self.index_configs[index_name] = new_config
+            self.collections[index_name] = []
+            self.pid_docid_maps[index_name] = {}
+            self.docid_pid_maps[index_name] = defaultdict(list)
+            self.docid_metadata_maps[index_name] = None
+            self.model_indices[index_name] = None # Will be created by .index()
+            return new_config
+        else:
+            raise FileNotFoundError(f"Index '{index_name}' not found at {current_index_path} and create_if_not_exists is False.")
+
+    def _invert_pid_docid_map(self, index_name: str) -> Dict[str, List[int]]:
         d = defaultdict(list)
-        for k, v in self.pid_docid_map.items():
+        if index_name not in self.pid_docid_maps:
+             if self.verbose > 0:
+                print(f"Warning: pid_docid_map not found for index '{index_name}' during inversion.")
+             return d
+        for k, v in self.pid_docid_maps[index_name].items():
             d[v].append(k)
         return d
 
-    def _get_collection_files_from_disk(self, index_path: str):
-        self.collection = srsly.read_json(index_path / "collection.json")
-        if os.path.exists(str(index_path / "docid_metadata_map.json")):
-            self.docid_metadata_map = srsly.read_json(
-                str(index_path / "docid_metadata_map.json")
+    def _get_collection_files_from_disk(self, index_name: str, index_path_str: str):
+        index_path = Path(index_path_str)
+        self.collections[index_name] = srsly.read_json(index_path / "collection.json")
+
+        if os.path.exists(index_path / "docid_metadata_map.json"):
+            self.docid_metadata_maps[index_name] = srsly.read_json(
+                index_path / "docid_metadata_map.json"
             )
         else:
-            self.docid_metadata_map = None
+            self.docid_metadata_maps[index_name] = None
 
         try:
-            self.pid_docid_map = srsly.read_json(str(index_path / "pid_docid_map.json"))
+            pid_docid_map_data = srsly.read_json(index_path / "pid_docid_map.json")
         except FileNotFoundError as err:
             raise FileNotFoundError(
-                "ERROR: Could not load pid_docid_map from index!",
-                "This is likely because you are loading an older, incompatible index.",
+                f"ERROR: Could not load pid_docid_map.json for index '{index_name}' from {index_path}!",
+                "This is likely because you are loading an older, incompatible index or the index is corrupted.",
             ) from err
 
-        # convert all keys to int when loading from file because saving converts to str
-        self.pid_docid_map = {
-            int(key): value for key, value in self.pid_docid_map.items()
+        self.pid_docid_maps[index_name] = {
+            int(key): value for key, value in pid_docid_map_data.items()
         }
-        self.docid_pid_map = self._invert_pid_docid_map()
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
 
-    def add_to_index(
-        self,
-        new_documents: List[str],
-        new_pid_docid_map: Dict[int, str],
-        new_docid_metadata_map: Optional[List[dict]] = None,
-        index_name: Optional[str] = None,
-        bsize: int = 32,
-        use_faiss: bool = False,
-    ):
-        self.index_name = index_name if index_name is not None else self.index_name
-        if self.index_name is None:
-            print(
-                "Cannot add to index without an index_name! Please provide one.",
-                "Returning empty results.",
-            )
-            return None
+    def _write_collection_files_to_disk(self, index_name: str):
+        if index_name not in self.index_paths:
+            raise ValueError(f"Index path for '{index_name}' not found. Ensure index is initialized.")
+        current_index_path = self.index_paths[index_name]
 
-        print(
-            "WARNING: add_to_index support is currently experimental!",
-            "add_to_index support will be more thorough in future versions",
-        )
+        os.makedirs(current_index_path, exist_ok=True)
 
-        if self.loaded_from_index:
-            index_root = self.config.root
-        else:
-            expected_path_segment = Path(self.config.experiment) / "indexes"
-            if str(expected_path_segment) in self.config.root:
-                index_root = self.config.root
-            else:
-                index_root = str(Path(self.config.root) / expected_path_segment)
-
-            if not self.collection:
-                collection_path = Path(index_root) / self.index_name / "collection.json"
-                if collection_path.exists():
-                    self._get_collection_files_from_disk(
-                        str(Path(index_root) / self.index_name)
-                    )
-
-        pid_values = set(self.pid_docid_map.values())
-        new_documents_with_ids = [
-            {"content": doc, "document_id": new_pid_docid_map[pid]} 
-            for pid, doc in enumerate(new_documents)
-            if new_pid_docid_map[pid] not in pid_values
-        ]
-        
-        max_existing_pid = max(self.pid_docid_map.keys(), default=-1)
-        for idx, doc in enumerate(new_documents_with_ids, start=max_existing_pid + 1):
-            self.pid_docid_map[idx] = doc["document_id"]
-
-        new_collection = [doc["content"] for doc in new_documents_with_ids]
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        # TODO We probably want to store some of this in the model_index directly.
-        self.model_index.add(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            index_root,
-            self.index_name,
-            new_collection,
-            verbose=self.verbose != 0,
-            bsize=bsize,
-            use_faiss=use_faiss,
-        )
-        self.config = self.model_index.config
-
-        # Update and serialize the index metadata + collection.
-        self.collection = self.collection + new_collection
-
-        # TODO This has inconsistent behavior for duplicates.
-        if new_docid_metadata_map is not None:
-            self.docid_metadata_map = self.docid_metadata_map or defaultdict(
-                lambda: None
-            )
-            self.docid_metadata_map.update(new_docid_metadata_map)
-
-        self.docid_pid_map = defaultdict(list)
-        for pid, docid in self.pid_docid_map.items():
-            self.docid_pid_map[docid].append(pid)
-
-        self._save_index_metadata()
-
-        print(
-            f"Successfully updated index with {len(new_documents_with_ids)} new documents!\n",
-            f"New index size: {len(self.collection)}",
-        )
-
-    def delete_from_index(
-        self,
-        document_ids: Union[TypeVar("T"), List[TypeVar("T")]],
-        index_name: Optional[str] = None,
-    ):
-        self.index_name = index_name if index_name is not None else self.index_name
-        if self.index_name is None:
-            print(
-                "Cannot delete from index without an index_name! Please provide one.",
-                "Returning empty results.",
-            )
-            return None
-
-        print(
-            "WARNING: delete_from_index support is currently experimental!",
-            "delete_from_index support will be more thorough in future versions",
-        )
-
-        pids_to_remove = []
-        for pid, docid in self.pid_docid_map.items():
-            if docid in document_ids:
-                pids_to_remove.append(pid)
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        # TODO We probably want to store some of this in the model_index directly.
-        self.model_index.delete(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            pids_to_remove,
-            verbose=self.verbose != 0,
-        )
-
-        # Update and serialize the index metadata + collection.
-        self.collection = [
-            doc for pid, doc in enumerate(self.collection) if pid not in pids_to_remove
-        ]
-        self.pid_docid_map = {
-            pid: docid
-            for pid, docid in self.pid_docid_map.items()
-            if pid not in pids_to_remove
-        }
-
-        if self.docid_metadata_map is not None:
-            self.docid_metadata_map = {
-                docid: metadata
-                for docid, metadata in self.docid_metadata_map.items()
-                if docid not in document_ids
-            }
-
-        self._save_index_metadata()
-
-        print(f"Successfully deleted documents with these IDs: {document_ids}")
-
-    def _write_collection_files_to_disk(self):
-        srsly.write_json(self.index_path + "/collection.json", self.collection)
-        srsly.write_json(self.index_path + "/pid_docid_map.json", self.pid_docid_map)
-        if self.docid_metadata_map is not None:
+        srsly.write_json(Path(current_index_path) / "collection.json", self.collections.get(index_name, []))
+        srsly.write_json(Path(current_index_path) / "pid_docid_map.json", self.pid_docid_maps.get(index_name, {}))
+        if self.docid_metadata_maps.get(index_name) is not None:
             srsly.write_json(
-                self.index_path + "/docid_metadata_map.json", self.docid_metadata_map
+                Path(current_index_path) / "docid_metadata_map.json", self.docid_metadata_maps[index_name]
             )
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
 
-        # update the in-memory inverted map every time the files are saved to disk
-        self.docid_pid_map = self._invert_pid_docid_map()
 
-    def _save_index_metadata(self):
-        assert self.model_index is not None
+    def _save_index_metadata(self, index_name: str):
+        config = self._get_or_load_index_context(index_name)
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            # This can happen if _save_index_metadata is called before ModelIndex is fully constructed (e.g. during .index())
+            # In such cases, the ModelIndex construction itself will save its metadata.
+            # However, if we are updating metadata for an *existing* model_index, it must be present.
+            # Let's check if the index path exists, implying a ModelIndex should have been loaded or is being built.
+            if not os.path.exists(self.index_paths[index_name]):
+                 raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot save metadata.")
+            if self.verbose > 0:
+                print(f"ModelIndex for '{index_name}' not yet available for metadata export, assuming it will be handled by ModelIndex.construct.")
+            # We still need to save RAGatouille specific files if they exist
+            self._write_collection_files_to_disk(index_name)
+            return
 
-        model_metadata = srsly.read_json(self.index_path + "/metadata.json")
-        index_config = self.model_index.export_metadata()
-        index_config["index_name"] = self.index_name
-        # Ensure that the additional metadata we store does not collide with anything else.
-        model_metadata["RAGatouille"] = {"index_config": index_config}  # type: ignore
-        srsly.write_json(self.index_path + "/metadata.json", model_metadata)
-        self._write_collection_files_to_disk()
+
+        current_index_path = self.index_paths[index_name]
+        os.makedirs(current_index_path, exist_ok=True) # Ensure directory exists
+
+        metadata_file_path = Path(current_index_path) / "metadata.json"
+
+        model_metadata = {}
+        if metadata_file_path.exists():
+            try:
+                model_metadata = srsly.read_json(str(metadata_file_path))
+            except ValueError: # Handles empty or malformed JSON
+                if self.verbose > 0:
+                    print(f"Warning: metadata.json for index '{index_name}' was malformed or empty. Creating a new one.")
+                model_metadata = {}
+
+
+        index_specific_config = model_index.export_metadata()
+        index_specific_config["index_name"] = index_name # Ensure index_name is part of the stored metadata
+
+        # Merge ColBERTConfig parameters into the RAGatouille specific metadata for completeness
+        # These are parameters like nbits, doc_maxlen etc. specific to this index
+
+        # Explicitly list relevant, serializable ColBERTConfig fields to store.
+        # This avoids trying to serialize complex objects or functions that might be part of ColBERTConfig's internal state.
+        relevant_colbert_config_fields = [
+            "nbits",
+            "doc_maxlen",
+            "query_maxlen",
+            "index_bsize",
+            "kmeans_niters",
+            "gpus", # Number of GPUs used for this index creation/config
+            "bsize", # General batch size, distinct from index_bsize
+            "similarity", # e.g., 'cosine' or 'l2'
+            # Add other simple, serializable config fields as deemed necessary
+            # Be cautious not to include fields that are functions, complex objects,
+            # or already managed (like root, experiment, index_name, checkpoint).
+        ]
+        config_to_store = {}
+        for field_name in relevant_colbert_config_fields:
+            if hasattr(config, field_name):
+                config_to_store[field_name] = getattr(config, field_name)
+
+        ragatouille_metadata = {
+            "index_config": index_specific_config, # From ModelIndex.export_metadata()
+            "colbert_config_params": config_to_store,
+        }
+
+        model_metadata["RAGatouille"] = ragatouille_metadata
+        srsly.write_json(str(metadata_file_path), model_metadata)
+        self._write_collection_files_to_disk(index_name)
+
 
     def index(
         self,
+        index_name: str,
         collection: List[str],
         pid_docid_map: Dict[int, str],
         docid_metadata_map: Optional[dict] = None,
-        index_name: Optional["str"] = None,
         max_document_length: int = 256,
         overwrite: Union[bool, str] = "reuse",
         bsize: int = 32,
         use_faiss: bool = False,
+        **kwargs, # For additional ColBERTConfig settings for this specific index
     ):
-        self.collection = collection
-        self.config.doc_maxlen = max_document_length
+        config_overrides = kwargs
+        config_overrides['doc_maxlen'] = max_document_length
+        config_overrides['index_bsize'] = bsize
+        # nbits is determined inside PLAIDModelIndex.build based on collection size
 
-        if index_name is not None:
-            if self.index_name is not None:
-                print(
-                    f"New index_name received!",
-                    f"Updating current index_name ({self.index_name}) to {index_name}",
-                )
-            self.index_name = index_name
-        else:
-            if self.index_name is None:
-                print(
-                    f"No index_name received!",
-                    f"Using default index_name ({self.checkpoint}_new_index)",
-                )
-            self.index_name = self.checkpoint + "new_index"
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=True, config_overrides=config_overrides)
+        # config is now the specific config for index_name
 
-        self.index_path = str(
-            Path(self.run_config.root)
-            / Path(self.run_config.experiment)
-            / "indexes"
-            / self.index_name
-        )
-        self.config.root = str(
-            Path(self.run_config.root) / Path(self.run_config.experiment) / "indexes"
-        )
+        self.collections[index_name] = collection
+        self.pid_docid_maps[index_name] = pid_docid_map
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+        self.docid_metadata_maps[index_name] = docid_metadata_map
 
-        self.pid_docid_map = pid_docid_map
+        # The ModelIndexFactory will use config.root, config.experiment, and index_name
+        # to determine the actual path for storing index files (e.g. IVF lists, centroids)
+        # config.root is already Path(self.index_root) / self.experiment_name / "indexes"
+        # So the factory will create files under config.root / index_name / ...
 
-        # inverted mapping for returning full docs
-        self.docid_pid_map = defaultdict(list)
-        for pid, docid in self.pid_docid_map.items():
-            self.docid_pid_map[docid].append(pid)
-
-        self.docid_metadata_map = docid_metadata_map
-
-        self.model_index = ModelIndexFactory.construct(
-            "PLAID",
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            overwrite,
-            verbose=self.verbose != 0,
+        model_index_instance = ModelIndexFactory.construct(
+            index_type="PLAID", # Currently PLAID is the main supported type
+            config=config, # Pass the specific config for this index
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=self.collections[index_name],
+            index_name=index_name, # This is crucial
+            overwrite=overwrite,
+            verbose=self.verbose > 0,
             bsize=bsize,
             use_faiss=use_faiss,
         )
-        self.config = self.model_index.config
-        self._save_index_metadata()
+        self.model_indices[index_name] = model_index_instance
+        # Update self.index_configs[index_name] with any modifications made by ModelIndexFactory (e.g. nbits)
+        self.index_configs[index_name] = model_index_instance.config
 
-        print("Done indexing!")
+        self._save_index_metadata(index_name)
 
-        return self.index_path
+        if self.verbose > 0:
+            print(f"Done indexing for index '{index_name}'!")
+        return self.index_paths[index_name]
+
+
+    def add_to_index(
+        self,
+        index_name: str,
+        new_documents: List[str], # These are chunks/passages
+        new_pid_docid_map_for_new_docs: Dict[int, str], # PIDs here are 0-indexed for new_documents
+        new_docid_metadata_map: Optional[Dict[str, Any]] = None, # Metadata for document_ids in new_documents
+        bsize: int = 32,
+        use_faiss: bool = False, # Relevant if index needs to be rebuilt
+    ):
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+        # config.root is Path(self.index_root) / self.experiment_name / "indexes"
+        # The model_index will operate within its specific directory: config.root / index_name
+
+        if self.verbose > 0:
+            print(
+            f"WARNING: add_to_index support for index '{index_name}' is currently experimental!",
+            "add_to_index support will be more thorough in future versions",
+            )
+
+        current_collection = self.collections.get(index_name, [])
+        current_pid_docid_map = self.pid_docid_maps.get(index_name, {})
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name, defaultdict(lambda: None))
+
+        # Filter out documents whose document_ids are already present
+        # This assumes new_pid_docid_map_for_new_docs gives the final intended document_id for each new passage
+        existing_doc_ids_in_index = set(current_pid_docid_map.values())
+
+        truly_new_passages_with_original_pid = [] # Stores (original_pid_in_new_docs, passage_content)
+        for original_pid, passage_content in enumerate(new_documents):
+            doc_id_for_this_passage = new_pid_docid_map_for_new_docs.get(original_pid)
+            if doc_id_for_this_passage is None:
+                if self.verbose > 0:
+                    print(f"Warning: Original PID {original_pid} in new_documents not found in new_pid_docid_map_for_new_docs. Skipping.")
+                continue
+            if doc_id_for_this_passage not in existing_doc_ids_in_index:
+                truly_new_passages_with_original_pid.append((original_pid, passage_content, doc_id_for_this_passage))
+
+        if not truly_new_passages_with_original_pid:
+            if self.verbose > 0:
+                print(f"No new unique documents to add to index '{index_name}'. All provided document IDs already exist or no valid new documents provided.")
+            return
+
+        new_collection_for_indexer = [item[1] for item in truly_new_passages_with_original_pid]
+
+        # Update persistent maps
+        max_existing_pid = max(current_pid_docid_map.keys(), default=-1)
+        for idx, (original_pid, passage_content, doc_id_for_this_passage) in enumerate(truly_new_passages_with_original_pid):
+            new_global_pid = max_existing_pid + 1 + idx
+            current_pid_docid_map[new_global_pid] = doc_id_for_this_passage
+
+        current_collection.extend(new_collection_for_indexer)
+
+        if new_docid_metadata_map:
+            current_docid_metadata_map.update(new_docid_metadata_map)
+
+        self.collections[index_name] = current_collection
+        self.pid_docid_maps[index_name] = current_pid_docid_map
+        self.docid_metadata_maps[index_name] = current_docid_metadata_map
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot add to it. Has it been indexed first?")
+
+        model_index.add(
+            config=config, # Pass the specific config
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=self.collections[index_name], # Pass the full current collection
+            index_root=config.root, # This is like Path(self.index_root) / self.experiment_name / "indexes"
+            index_name=index_name, # Crucial
+            new_collection=new_collection_for_indexer, # Only the truly new passages
+            verbose=self.verbose > 0,
+            bsize=bsize,
+            use_faiss=use_faiss, # For potential rebuild
+        )
+        self.index_configs[index_name] = model_index.config # Update with potentially modified config from .add()
+
+        self._save_index_metadata(index_name)
+
+        if self.verbose > 0:
+            print(
+                f"Successfully attempted to update index '{index_name}' with {len(new_collection_for_indexer)} new passages!\n",
+                f"New index size for '{index_name}': {len(self.collections[index_name])} passages.",
+            )
+
+
+    def delete_from_index(
+        self,
+        index_name: str,
+        document_ids: Union[TypeVar("T"), List[TypeVar("T")]], # Document IDs to remove
+    ):
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+
+        if self.verbose > 0:
+            print(
+                f"WARNING: delete_from_index support for index '{index_name}' is currently experimental!",
+                "delete_from_index support will be more thorough in future versions",
+            )
+
+        current_collection = self.collections.get(index_name)
+        current_pid_docid_map = self.pid_docid_maps.get(index_name)
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name)
+
+        if not current_collection or not current_pid_docid_map:
+            if self.verbose > 0:
+                print(f"Index '{index_name}' appears to be empty or not loaded. Cannot delete.")
+            return
+
+        pids_to_remove_from_indexer = []
+        doc_ids_to_remove_set = set(document_ids if isinstance(document_ids, list) else [document_ids])
+
+        new_pid_docid_map = {}
+        kept_passage_indices = [] # 0-indexed relative to current_collection
+
+        # Iterate through current PIDs to find which ones to remove
+        # And construct the list of PIDs for the Indexer.remove() method
+        for pid_key, docid_val in current_pid_docid_map.items():
+            if docid_val in doc_ids_to_remove_set:
+                pids_to_remove_from_indexer.append(pid_key)
+            else:
+                # This passage is kept. We need its content for the new collection.
+                # The pid_key is its current global PID, which is also its index in current_collection.
+                # We need to map this old pid_key to a new pid_key if PIDs are compacted later.
+                # For now, just track which passages are kept.
+                # The indexer.remove() takes global PIDs.
+                pass # Handled by the model_index.delete itself based on pids_to_remove_from_indexer
+
+        if not pids_to_remove_from_indexer:
+            if self.verbose > 0:
+                print(f"No documents corresponding to the given IDs found in index '{index_name}'. Nothing to delete.")
+            return
+
+        model_index = self.model_indices.get(index_name)
+        if model_index is None:
+            raise ValueError(f"ModelIndex for '{index_name}' not found. Cannot delete. Has it been indexed first?")
+
+        model_index.delete(
+            config=config,
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=current_collection, # Pass the full current collection
+            index_name=index_name,
+            pids_to_remove=pids_to_remove_from_indexer,
+            verbose=self.verbose > 0,
+        )
+        self.index_configs[index_name] = model_index.config
+
+
+        # After indexer has processed deletions, update our local high-level trackings
+        # Rebuild collections, pid_docid_maps, etc. based on what remains
+        # This is simpler than trying to surgically remove and re-index PIDs.
+        # The indexer internally handles tombstones or compaction.
+        # For our metadata, we effectively "reload" it reflecting the deletions.
+
+        # A bit inefficient, but safest: re-filter based on the pids *not* removed
+        new_collection_content = []
+        new_pid_to_docid = {}
+        next_new_pid = 0
+        for old_pid, passage_content in enumerate(current_collection):
+            if old_pid not in pids_to_remove_from_indexer: # If this passage was NOT deleted by indexer
+                new_collection_content.append(passage_content)
+                # Map its original document_id to the new PID
+                original_doc_id = current_pid_docid_map.get(old_pid)
+                if original_doc_id: # Should always exist
+                    new_pid_to_docid[next_new_pid] = original_doc_id
+                next_new_pid += 1
+
+        self.collections[index_name] = new_collection_content
+        self.pid_docid_maps[index_name] = new_pid_to_docid
+
+        if current_docid_metadata_map is not None:
+            self.docid_metadata_maps[index_name] = {
+                docid: metadata
+                for docid, metadata in current_docid_metadata_map.items()
+                if docid not in doc_ids_to_remove_set
+            }
+
+        self.docid_pid_maps[index_name] = self._invert_pid_docid_map(index_name)
+        self._save_index_metadata(index_name)
+
+        if self.verbose > 0:
+            print(f"Successfully deleted documents with IDs {doc_ids_to_remove_set} from index '{index_name}'.")
+            print(f"New index size for '{index_name}': {len(self.collections[index_name])} passages.")
+
 
     def search(
         self,
+        index_name: str,
         query: Union[str, list[str]],
-        index_name: Optional["str"] = None,
         k: int = 10,
         force_fast: bool = False,
         zero_index_ranks: bool = False,
-        doc_ids: Optional[List[str]] = None,
+        doc_ids: Optional[List[str]] = None, # Filter search to these document_ids
     ):
-        pids = None
+        print("1")
+        config = self._get_or_load_index_context(index_name, create_if_not_exists=False)
+        model_index = self.model_indices.get(index_name)
+        current_collection = self.collections.get(index_name)
+        current_pid_docid_map = self.pid_docid_maps.get(index_name)
+        current_docid_pid_map = self.docid_pid_maps.get(index_name)
+        current_docid_metadata_map = self.docid_metadata_maps.get(index_name)
+        print("2", current_pid_docid_map)
+
+        if model_index is None or not current_collection or not current_pid_docid_map or not current_docid_pid_map:
+            raise ValueError(f"Index '{index_name}' is not properly loaded or is empty. Cannot search.")
+        print("3")
+        pids_to_search_within = None
         if doc_ids is not None:
-            pids = []
-            for doc_id in doc_ids:
-                pids.extend(self.docid_pid_map[doc_id])
-
-        force_reload = index_name is not None and index_name != self.index_name
-        if index_name is not None:
-            if self.index_name is not None and self.index_name != index_name:
-                print(
-                    f"New index_name received!",
-                    f"Updating current index_name ({self.index_name}) to {index_name}",
-                )
-            self.index_name = index_name
-        else:
-            if self.index_name is None:
-                print(
-                    "Cannot search without an index_name! Please provide one.",
-                    "Returning empty results.",
-                )
-                return None
-
-        # TODO We may want to load an existing index here instead;
-        #      For now require that either index() was called, or an existing one was loaded.
-        assert self.model_index is not None
-
-        results = self.model_index.search(
-            self.config,
-            self.checkpoint,
-            self.collection,
-            self.index_name,
-            self.base_model_max_tokens,
-            query,
-            k,
-            pids,
-            force_reload,
+            pids_to_search_within = []
+            for doc_id_filter in doc_ids:
+                pids_to_search_within.extend(current_docid_pid_map.get(doc_id_filter, []))
+            if not pids_to_search_within:
+                if self.verbose > 0:
+                    print(f"Warning: doc_ids filter provided for index '{index_name}', but no passages found for these doc_ids. Returning empty results.")
+                return [] if isinstance(query, str) else [[] for _ in query]
+        print("4")
+        # The model_index search needs the full collection context if it's not already loaded by its Searcher
+        # However, PLAIDModelIndex typically loads its own collection view.
+        results_from_model_index = model_index.search(
+            config=config,
+            checkpoint=str(self.base_pretrained_model_name_or_path),
+            collection=current_collection, # Provided for context, Searcher might use its own view
+            index_name=index_name,
+            base_model_max_tokens=self.base_model_max_tokens,
+            query=query,
+            k=k,
+            pids=pids_to_search_within, # Pass the filtered PIDs to the searcher
+            force_reload=False, # We handle context loading; force_reload here is for searcher specific state.
             force_fast=force_fast,
         )
-
+        print("5")
         to_return = []
-        for result in results:
+        for result_group in results_from_model_index: # result_group is for one query
             result_for_query = []
-            for id_, rank, score in zip(*result):
-                document_id = self.pid_docid_map[id_]
+            # result_group is typically (passage_ids, ranks, scores)
+            passage_pids, ranks, scores = result_group[0], result_group[1], result_group[2]
+
+            for passage_pid, rank_val, score_val in zip(passage_pids, ranks, scores):
+                document_id_for_passage = current_pid_docid_map.get(int(passage_pid))
+                if document_id_for_passage is None:
+                    if self.verbose > 0:
+                        print(f"Warning: Passage PID {passage_pid} from search results not found in pid_docid_map for index '{index_name}'. Skipping.")
+                    continue
+
+                # Ensure passage_pid is valid index for current_collection
+                if not (0 <= int(passage_pid) < len(current_collection)):
+                    if self.verbose > 0:
+                        print(f"Warning: Passage PID {passage_pid} from search results is out of bounds for current_collection of index '{index_name}'. Skipping.")
+                    continue
+
+
                 result_dict = {
-                    "content": self.collection[id_],
-                    "score": score,
-                    "rank": rank - 1 if zero_index_ranks else rank,
-                    "document_id": document_id,
-                    "passage_id": id_,
+                    "content": current_collection[int(passage_pid)],
+                    "score": float(score_val),
+                    "rank": int(rank_val) - 1 if zero_index_ranks else int(rank_val),
+                    "document_id": document_id_for_passage,
+                    "passage_id": int(passage_pid), # This is the internal PID used by ColBERT
                 }
 
-                if self.docid_metadata_map is not None:
-                    if document_id in self.docid_metadata_map:
-                        doc_metadata = self.docid_metadata_map[document_id]
+                if current_docid_metadata_map is not None:
+                    if document_id_for_passage in current_docid_metadata_map:
+                        doc_metadata = current_docid_metadata_map[document_id_for_passage]
                         result_dict["document_metadata"] = doc_metadata
 
                 result_for_query.append(result_dict)
-
             to_return.append(result_for_query)
 
-        if len(to_return) == 1:
-            return to_return[0]
-        return to_return
+        return to_return[0] if isinstance(query, str) and len(to_return) == 1 else to_return
 
-    def _search(self, query: str, k: int, pids: Optional[List[int]] = None):
-        assert self.model_index is not None
-        return self.model_index._search(query, k, pids)
 
-    def _batch_search(self, query: list[str], k: int):
-        assert self.model_index is not None
-        return self.model_index._batch_search(query, k)
+    # Methods for index-free operations (rank, encode, search_encoded_docs)
+    # These operate on the base model and don't interact with specific disk-based indices.
+    # They use self.inference_ckpt directly.
 
-    def train(self, data_dir, training_config: ColBERTConfig):
-        training_config = ColBERTConfig.from_existing(self.config, training_config)
-        training_config.nway = 2
-        with Run().context(self.run_config):
-            trainer = Trainer(
-                triples=str(data_dir / "triples.train.colbert.jsonl"),
-                queries=str(data_dir / "queries.train.colbert.tsv"),
-                collection=str(data_dir / "corpus.train.colbert.tsv"),
-                config=training_config,
-            )
+    def _set_inference_max_tokens(
+        self, documents: list[str], max_tokens: Union[Literal["auto"], int] = "auto"
+    ):
+        # This state should be temporary per call for index-free, or managed if we cache encodings
+        if not hasattr(self, "_temp_inference_ckpt_len_set") or self._temp_inference_ckpt_len_set is False:
+            if max_tokens == "auto":
+                # Calculate based on documents, ensuring it doesn't exceed base_model_max_tokens
+                percentile_90 = np.percentile([len(x.split(" ")) for x in documents], 90)
+                effective_max_tokens = min(
+                    math.floor((math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1),
+                    self.base_model_max_tokens,
+                )
+                effective_max_tokens = max(256, int(effective_max_tokens)) # Ensure a minimum reasonable length
+            else:
+                effective_max_tokens = min(int(max_tokens), self.base_model_max_tokens)
 
-            trainer.train(checkpoint=self.checkpoint)
-            return trainer.best_checkpoint_path()
+            if effective_max_tokens > 300 and self.verbose > 0 and max_tokens == "auto":
+                 print(
+                    f"Your documents are roughly {percentile_90} tokens long at the 90th percentile for this batch!",
+                    "This is quite long and might slow down reranking!\n",
+                    "Provide fewer documents, build smaller chunks or run on GPU if it takes too long for your needs!",
+                )
+
+            # Temporarily adjust the main inference_ckpt for this operation
+            # A more robust solution might involve creating a temporary tokenizer instance
+            self.inference_ckpt.colbert_config.doc_maxlen = effective_max_tokens
+            self.inference_ckpt.doc_tokenizer.doc_maxlen = effective_max_tokens
+            self._temp_inference_ckpt_len_set = True # Mark that we've set it for this call scope
+
+
+    def _reset_inference_max_tokens(self):
+        # Reset to base model's default after the operation
+        if hasattr(self, "_temp_inference_ckpt_len_set") and self._temp_inference_ckpt_len_set:
+            base_doc_maxlen = self.inference_ckpt.bert.config.max_position_embeddings - 4 # Re-calculate default
+            self.inference_ckpt.colbert_config.doc_maxlen = base_doc_maxlen
+            self.inference_ckpt.doc_tokenizer.doc_maxlen = base_doc_maxlen
+            del self._temp_inference_ckpt_len_set
+
 
     def _colbert_score(self, Q, D_padded, D_mask):
-        if ColBERTConfig().total_visible_gpus > 0:
+        # Standard ColBERT scoring logic
+        if ColBERTConfig().total_visible_gpus > 0: # Check global config for GPU availability
             Q, D_padded, D_mask = Q.cuda(), D_padded.cuda(), D_mask.cuda()
 
         assert Q.dim() == 3, Q.size()
@@ -465,108 +644,6 @@ class ColBERT(LateInteractionModel):
         scores = scores.max(1).values
         return scores.sum(-1)
 
-    def _index_free_search(
-        self,
-        embedded_queries,
-        documents: list[str],
-        embedded_docs,
-        doc_mask,
-        k: int = 10,
-        zero_index: bool = False,
-    ):
-        results = []
-
-        for query in embedded_queries:
-            results_for_query = []
-            scores = self._colbert_score(query, embedded_docs, doc_mask)
-            sorted_scores = torch.topk(scores, k)
-            for rank, doc_idx in enumerate(sorted_scores.indices.tolist()):
-                result = {
-                    "content": documents[doc_idx],
-                    "score": float(scores[doc_idx]),
-                    "rank": rank - 1 if zero_index else rank,
-                    "result_index": doc_idx,
-                }
-                results_for_query.append(result)
-            results.append(results_for_query)
-
-        if len(results) == 1:
-            return results[0]
-
-        return results
-
-    def _set_inference_max_tokens(
-        self, documents: list[str], max_tokens: Union[Literal["auto"], int] = "auto"
-    ):
-        if (
-            not hasattr(self, "inference_ckpt_len_set")
-            or self.inference_ckpt_len_set is False
-        ):
-            if max_tokens == "auto":
-                max_tokens = self.base_model_max_tokens
-            else:
-                max_tokens = int(max_tokens)
-            if max_tokens > self.base_model_max_tokens:
-                max_tokens = self.base_model_max_tokens
-                percentile_90 = np.percentile(
-                    [len(x.split(" ")) for x in documents], 90
-                )
-                max_tokens = min(
-                    math.floor((math.ceil((percentile_90 * 1.35) / 32) * 32) * 1.1),
-                    self.base_model_max_tokens,
-                )
-                max_tokens = max(256, max_tokens)
-
-                if max_tokens > 300:
-                    print(
-                        f"Your documents are roughly {percentile_90} tokens long at the 90th percentile!",
-                        "This is quite long and might slow down reranking!\n",
-                        "Provide fewer documents, build smaller chunks or run on GPU",
-                        "if it takes too long for your needs!",
-                    )
-            self.inference_ckpt.colbert_config.max_doclen = max_tokens
-            self.inference_ckpt.doc_tokenizer.doc_maxlen = max_tokens
-            self.inference_ckpt_len_set = True
-
-    def _index_free_retrieve(
-        self,
-        query: Union[str, list[str]],
-        documents: list[str],
-        k: int,
-        max_tokens: Union[Literal["auto"], int] = "auto",
-        zero_index: bool = False,
-        bsize: Union[Literal["auto"], int] = "auto",
-    ):
-        self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
-
-        if k > len(documents):
-            print("k value cannot be larger than the number of documents! aborting...")
-            return None
-        if len(documents) > 1000:
-            print(
-                "Please note ranking in-memory is not optimised for large document counts! ",
-                "Consider building an index and using search instead!",
-            )
-        if len(set(documents)) != len(documents):
-            print(
-                "WARNING! Your documents have duplicate entries! ",
-                "This will slow down calculation and may yield subpar results",
-            )
-
-        embedded_queries = self._encode_index_free_queries(query, bsize=bsize)
-        embedded_docs, doc_mask = self._encode_index_free_documents(
-            documents, bsize=bsize
-        )
-
-        return self._index_free_search(
-            embedded_queries=embedded_queries,
-            documents=documents,
-            embedded_docs=embedded_docs,
-            doc_mask=doc_mask,
-            k=k,
-            zero_index=zero_index,
-        )
-
     def _encode_index_free_queries(
         self,
         queries: Union[str, list[str]],
@@ -576,172 +653,299 @@ class ColBERT(LateInteractionModel):
             bsize = 32
         if isinstance(queries, str):
             queries = [queries]
+
+        # Temporarily adjust query_maxlen for this batch of queries
+        original_query_maxlen = self.inference_ckpt.query_tokenizer.query_maxlen
         maxlen = max([int(len(x.split(" ")) * 1.35) for x in queries])
         self.inference_ckpt.query_tokenizer.query_maxlen = max(
-            min(maxlen, self.base_model_max_tokens), 32
+            min(maxlen, self.base_model_max_tokens), 32 # Maximize length but not over model capacity
         )
+
         embedded_queries = [
             x.unsqueeze(0)
-            for x in self.inference_ckpt.queryFromText(queries, bsize=bsize)
+            for x in self.inference_ckpt.queryFromText(queries, bsize=bsize, to_cpu=True) # Ensure CPU for general use
         ]
+
+        self.inference_ckpt.query_tokenizer.query_maxlen = original_query_maxlen # Restore
         return embedded_queries
 
     def _encode_index_free_documents(
         self,
         documents: list[str],
         bsize: Union[Literal["auto"], int] = "auto",
-        verbose: bool = True,
+        verbose_override: Optional[bool] = None,
     ):
+        effective_verbose = self.verbose > 0 if verbose_override is None else verbose_override
+
+        # bsize calculation needs to consider the currently set doc_maxlen on inference_ckpt
+        current_doc_maxlen_for_bsize_calc = self.inference_ckpt.doc_tokenizer.doc_maxlen
         if bsize == "auto":
             bsize = 32
-            if self.inference_ckpt.doc_tokenizer.doc_maxlen > 512:
-                bsize = max(
-                    1,
-                    int(
-                        32
-                        / (
-                            2
-                            ** round(
-                                math.log(
-                                    self.inference_ckpt.doc_tokenizer.doc_maxlen, 2
-                                )
-                            )
-                            / 512
-                        )
-                    ),
-                )
-                print("BSIZE:")
-                print(bsize)
-        embedded_docs = self.inference_ckpt.docFromText(
-            documents, bsize=bsize, showprogress=verbose
+            if current_doc_maxlen_for_bsize_calc > 512: # Example threshold
+                # Reduce bsize proportionally if doc_maxlen is very large to avoid OOM
+                factor = 2 ** round(math.log(current_doc_maxlen_for_bsize_calc / 512, 2))
+                bsize = max(1, int(32 / factor))
+                if effective_verbose:
+                    print(f"Auto bsize adjusted to {bsize} due to large doc_maxlen ({current_doc_maxlen_for_bsize_calc})")
+
+        # D_encoder returns (tensor, count). We only need tensor.
+        # to_cpu=True to ensure results are on CPU if not using GPU for ColBERT overall
+        embedded_docs_tensor = self.inference_ckpt.docFromText(
+            documents, bsize=bsize, showprogress=effective_verbose, to_cpu=True
         )[0]
-        doc_mask = torch.full(embedded_docs.shape[:2], -float("inf")).to(
-            embedded_docs.device
-        )
-        return embedded_docs, doc_mask
+
+        # Mask is usually for padding in ColBERT, here we create a full mask assuming all tokens are valid for scoring.
+        # This might need adjustment if specific masking strategies are required for index-free.
+        # For simple maxsim, the mask might not be strictly necessary if D_padded already handles lengths.
+        # However, _colbert_score expects D_mask.
+        doc_mask = torch.zeros(embedded_docs_tensor.shape[:2], device=embedded_docs_tensor.device) # All valid
+
+        return embedded_docs_tensor, doc_mask
+
+
+    def _index_free_search(
+        self,
+        embedded_queries, # List of query tensors
+        documents: list[str], # Original documents for retrieval
+        embedded_docs, # Tensor of document embeddings
+        doc_mask, # Document masks
+        k: int = 10,
+        zero_index_ranks: bool = False,
+    ):
+        results_all_queries = []
+
+        for query_tensor in embedded_queries: # query_tensor is [1, num_tokens, dim]
+            scores = self._colbert_score(query_tensor, embedded_docs, doc_mask) # scores will be [num_docs]
+
+            # Ensure k is not larger than number of documents
+            effective_k = min(k, embedded_docs.size(0))
+
+            top_k_scores, top_k_indices = torch.topk(scores, effective_k)
+
+            results_for_single_query = []
+            for rank, doc_idx_in_batch in enumerate(top_k_indices.tolist()):
+                result = {
+                    "content": documents[doc_idx_in_batch],
+                    "score": float(scores[doc_idx_in_batch]), # Get original score before topk for consistency
+                    "rank": rank if zero_index_ranks else rank + 1,
+                    "result_index": doc_idx_in_batch, # Index within the provided documents list
+                }
+                results_for_single_query.append(result)
+            results_all_queries.append(results_for_single_query)
+
+        return results_all_queries[0] if len(results_all_queries) == 1 else results_all_queries
+
 
     def rank(
         self,
-        query: str,
+        query: str, # Single query string for ranking
         documents: list[str],
         k: int = 10,
         zero_index_ranks: bool = False,
-        bsize: int = 32,
+        bsize: Union[Literal["auto"], int] = "auto",
+        max_tokens: Union[Literal["auto"], int] = "auto",
     ):
-        self._set_inference_max_tokens(documents=documents, max_tokens="auto")
-        self.inference_ckpt_len_set = False
-        return self._index_free_retrieve(
-            query, documents, k, zero_index=zero_index_ranks, bsize=bsize
-        )
+        if not documents:
+            return []
+        if k > len(documents):
+            if self.verbose > 0:
+                print(f"Warning: k value ({k}) for rank is larger than the number of documents ({len(documents)}). Adjusting k.")
+            k = len(documents)
 
+        try:
+            self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
+
+            # Encode query
+            embedded_queries = self._encode_index_free_queries([query], bsize=bsize) # List with one query tensor
+
+            # Encode documents
+            # verbose_override=False for document encoding within rank unless self.verbose is high
+            embedded_docs, doc_mask = self._encode_index_free_documents(documents, bsize=bsize, verbose_override=(self.verbose > 1))
+
+            # Perform search (ranking)
+            # _index_free_search returns list of lists; since it's one query, take first element
+            ranked_results = self._index_free_search(
+                embedded_queries, documents, embedded_docs, doc_mask, k, zero_index_ranks
+            )
+            return ranked_results # This will be the list of dicts for the single query
+        finally:
+            self._reset_inference_max_tokens()
+
+
+    # --- Methods for managing cached encoded documents (experimental) ---
+    # These would allow encoding a large set once and searching over it multiple times.
     def encode(
         self,
         documents: list[str],
-        document_metadatas: Optional[list[dict]] = None,
+        document_metadatas: Optional[List[Optional[Dict[str, Any]]]] = None, # Optional metadata per document
         bsize: int = 32,
         max_tokens: Union[Literal["auto"], int] = "auto",
-        verbose: bool = True,
+        verbose_override: Optional[bool] = None,
     ):
-        self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
-        encodings, doc_masks = self._encode_index_free_documents(
-            documents, bsize=bsize, verbose=verbose
-        )
-        encodings = torch.cat(
-            [
-                encodings,
-                torch.zeros(
-                    (
-                        encodings.shape[0],
-                        self.inference_ckpt.doc_tokenizer.doc_maxlen
-                        - encodings.shape[1],
-                        encodings.shape[2],
-                    )
-                ).to(device=encodings.device),
-            ],
-            dim=1,
-        )
-        doc_masks = torch.cat(
-            [
-                doc_masks,
-                torch.full(
-                    (
-                        doc_masks.shape[0],
-                        self.inference_ckpt.colbert_config.max_doclen
-                        - doc_masks.shape[1],
-                    ),
-                    -float("inf"),
-                ).to(device=doc_masks.device),
-            ],
-            dim=1,
-        )
+        """Encodes documents and stores them in memory for subsequent `search_encoded_docs` calls."""
+        if not hasattr(self, "_cached_encodings"):
+            self._cached_encodings = {
+                "collection": [],
+                "metadatas": [],
+                "embeddings": None, # Will be a tensor
+                "masks": None, # Will be a tensor
+                "doc_maxlen_at_encoding": 0,
+            }
 
-        if verbose:
-            print("Shapes:")
-            print(f"encodings: {encodings.shape}")
-            print(f"doc_masks: {doc_masks.shape}")
+        effective_verbose = self.verbose > 0 if verbose_override is None else verbose_override
+        try:
+            self._set_inference_max_tokens(documents=documents, max_tokens=max_tokens)
 
-        if hasattr(self, "in_memory_collection"):
-            if self.in_memory_metadata is not None:
-                if document_metadatas is None:
-                    self.in_memory_metadatas.extend([None] * len(documents))
-                else:
-                    self.in_memory_metadata.extend(document_metadatas)
-            elif document_metadatas is not None:
-                self.in_memory_metadata = [None] * len(self.in_memory_collection)
-                self.in_memory_metadata.extend(document_metadatas)
+            # Store the doc_maxlen used for this batch, important if concatenating
+            current_encoding_doc_maxlen = self.inference_ckpt.doc_tokenizer.doc_maxlen
 
-            self.in_memory_collection.extend(documents)
-
-            # add 0 padding to encodings so they're self.inference_ckpt.doc_tokenizer.doc_maxlen length
-
-            self.in_memory_embed_docs = torch.cat(
-                [self.in_memory_embed_docs, encodings], dim=0
+            new_embeddings, new_masks = self._encode_index_free_documents(
+                documents, bsize=bsize, verbose_override=effective_verbose
             )
-            self.doc_masks = torch.cat([self.doc_masks, doc_masks], dim=0)
 
-        else:
-            self.in_memory_collection = documents
-            self.in_memory_metadata = document_metadatas
-            self.in_memory_embed_docs = encodings
-            self.doc_masks = doc_masks
+            # Normalize embedding shapes for concatenation if doc_maxlen changed
+            if self._cached_encodings["embeddings"] is not None:
+                # If cached encodings exist, all new encodings must match its doc_maxlen
+                # Or, more robustly, pad all to the largest encountered doc_maxlen
+                # For now, let's assume subsequent encodes try to match or clear first
+                if current_encoding_doc_maxlen != self._cached_encodings["doc_maxlen_at_encoding"]:
+                    # This logic needs to be robust: pad existing or new to match a common dimension.
+                    # Simplest for now: raise error or warn, require consistent max_tokens or clear cache.
+                    print(f"Warning: max_tokens for this encode call ({current_encoding_doc_maxlen}) differs from cached ({self._cached_encodings['doc_maxlen_at_encoding']}). Results may be inconsistent if concatenating. Consider clearing cache or using consistent max_tokens.")
+                    # Fallback: Pad new_embeddings to match cached dimension if smaller, or re-encode all if larger (costly)
+                    # This padding ensures self._colbert_score doesn't fail on shape mismatch.
+                    if new_embeddings.shape[1] < self._cached_encodings["doc_maxlen_at_encoding"]:
+                        padding_size = self._cached_encodings["doc_maxlen_at_encoding"] - new_embeddings.shape[1]
+                        pad_tensor = torch.zeros(new_embeddings.shape[0], padding_size, new_embeddings.shape[2], device=new_embeddings.device)
+                        new_embeddings = torch.cat([new_embeddings, pad_tensor], dim=1)
+                        # Also pad masks if they are length-dependent (current D_mask from _encode_index_free is not, but good practice)
+
+            self._cached_encodings["collection"].extend(documents)
+            if document_metadatas:
+                self._cached_encodings["metadatas"].extend(document_metadatas)
+            else:
+                self._cached_encodings["metadatas"].extend([None] * len(documents))
+
+            if self._cached_encodings["embeddings"] is None:
+                self._cached_encodings["embeddings"] = new_embeddings
+                self._cached_encodings["masks"] = new_masks
+                self._cached_encodings["doc_maxlen_at_encoding"] = current_encoding_doc_maxlen
+            else:
+                # Ensure device consistency before cat
+                device = self._cached_encodings["embeddings"].device
+                self._cached_encodings["embeddings"] = torch.cat(
+                    [self._cached_encodings["embeddings"], new_embeddings.to(device)], dim=0
+                )
+                self._cached_encodings["masks"] = torch.cat(
+                    [self._cached_encodings["masks"], new_masks.to(device)], dim=0
+                )
+            if effective_verbose:
+                print(f"Encoded {len(documents)} documents. Total cached: {len(self._cached_encodings['collection'])}.")
+
+        finally:
+            self._reset_inference_max_tokens()
+
 
     def search_encoded_docs(
         self,
         queries: Union[str, list[str]],
         k: int = 10,
-        bsize: int = 32,
+        bsize: int = 32, # For query encoding
+        zero_index_ranks: bool = False,
     ):
-        queries = self._encode_index_free_queries(queries, bsize=bsize)
+        if not hasattr(self, "_cached_encodings") or self._cached_encodings["embeddings"] is None:
+            print("No documents have been encoded and cached. Call .encode() first.")
+            return [] if isinstance(queries, str) else [[] for _ in queries]
+
+        # Encode queries (max_tokens for queries is handled by _encode_index_free_queries)
+        embedded_queries = self._encode_index_free_queries(queries, bsize=bsize)
+
         results = self._index_free_search(
-            embedded_queries=queries,
-            documents=self.in_memory_collection,
-            embedded_docs=self.in_memory_embed_docs,
-            doc_mask=self.doc_masks,
-            k=k,
+            embedded_queries,
+            self._cached_encodings["collection"],
+            self._cached_encodings["embeddings"],
+            self._cached_encodings["masks"],
+            k,
+            zero_index_ranks,
         )
-        if self.in_memory_metadata is not None:
-            for result in results:
-                result["document_metadata"] = self.in_memory_metadata[
-                    result["result_index"]
-                ]
-        return results
+
+        # Add metadata if available
+        # results is either a list of dicts (single query) or list of lists of dicts (multi-query)
+        def add_meta(single_query_results_list):
+            for r_dict in single_query_results_list:
+                doc_meta = self._cached_encodings["metadatas"][r_dict["result_index"]]
+                if doc_meta:
+                    r_dict["document_metadata"] = doc_meta
+            return single_query_results_list
+
+        if isinstance(queries, str): # Single query, results is a list of dicts
+            return add_meta(results)
+        else: # Multiple queries, results is a list of lists of dicts
+            return [add_meta(res_list) for res_list in results]
+
 
     def clear_encoded_docs(self, force: bool = False):
+        if not hasattr(self, "_cached_encodings") or self._cached_encodings["embeddings"] is None:
+            print("No cached encodings to clear.")
+            return
+
         if not force:
-            print(
-                "All in-memory encodings will be deleted in 10 seconds, interrupt now if you want to keep them!"
-            )
-            print("...")
-            time.sleep(10)
-        del self.in_memory_collection
-        del self.in_memory_metadata
-        del self.in_memory_embed_docs
-        del self.doc_masks
-        del self.inference_ckpt_len_set
+            if self.verbose > 0:
+                print("All in-memory encodings will be deleted in 5 seconds. Interrupt to cancel.")
+            time.sleep(5)
+
+        self._cached_encodings = {
+            "collection": [], "metadatas": [], "embeddings": None, "masks": None, "doc_maxlen_at_encoding":0
+        }
+        if torch.cuda.is_available(): # Try to free GPU memory if used
+            torch.cuda.empty_cache()
+        if self.verbose > 0:
+            print("Cached encoded documents cleared.")
+
+
+    # --- Training method (largely unchanged, uses global RunContext) ---
+    def train(self, index_name_for_config: Optional[str], data_dir: Union[str, Path], training_config_overrides: Dict[str, Any]) -> str:
+        # Training often creates a new model/checkpoint.
+        # It needs a ColBERTConfig. If an index_name is provided, use its config as a base.
+        # Otherwise, use the base_model_config.
+        if index_name_for_config:
+            base_train_config = self._get_or_load_index_context(index_name_for_config, create_if_not_exists=False) # Should exist
+        else:
+            base_train_config = self.base_model_config # Default if no specific index config
+
+        # Construct ColBERTConfig from the dictionary of overrides
+        override_config_obj = ColBERTConfig(**training_config_overrides)
+        final_training_config = ColBERTConfig.from_existing(base_train_config, override_config_obj)
+        final_training_config.nway = 2 # Common setting for ColBERT training
+
+        data_path = Path(data_dir)
+
+        # Run().context(self.run_config) is already active globally for the class instance
+        trainer = Trainer(
+            triples=str(data_path / "triples.train.colbert.jsonl"),
+            queries=str(data_path / "queries.train.colbert.tsv"),
+            collection=str(data_path / "corpus.train.colbert.tsv"),
+            config=final_training_config, # Pass the resolved training config
+        )
+        # Trainer uses the checkpoint from the ColBERTConfig if not specified otherwise
+        trainer.train(checkpoint=str(self.base_pretrained_model_name_or_path))
+
+        if self.verbose > 0:
+            print(f"Training complete. Best checkpoint saved to: {trainer.path_}") # trainer.path_ is new standard
+        return trainer.path_
+
 
     def __del__(self):
-        # Clean up context
+        # Clean up global ColBERT context
         try:
-            self.run_context.__exit__(None, None, None)
+            if hasattr(self, 'run_context') and self.run_context:
+                self.run_context.__exit__(None, None, None)
         except Exception:
-            print("INFO: Tried to clean up context but failed!")
+            if self.verbose > 0: # Only print if verbose
+                print("INFO: Tried to clean up ColBERT RunContext but failed. This is usually not critical.")
+
+        # Clear cached encodings if any, to free memory
+        if hasattr(self, "_cached_encodings"):
+            del self._cached_encodings
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -340,7 +340,13 @@ class ColBERT(LateInteractionModel):
 
         current_collection = self.collections.get(index_name, [])
         current_pid_docid_map = self.pid_docid_maps.get(index_name, {})
-        current_docid_metadata_map = self.docid_metadata_maps.get(index_name, defaultdict(lambda: None))
+        # Ensure current_docid_metadata_map is a dict, not None, before .update()
+        current_docid_metadata_map_val = self.docid_metadata_maps.get(index_name)
+        if current_docid_metadata_map_val is None:
+            current_docid_metadata_map = {}
+        else:
+            current_docid_metadata_map = current_docid_metadata_map_val
+
 
         # Filter out documents whose document_ids are already present
         # This assumes new_pid_docid_map_for_new_docs gives the final intended document_id for each new passage
@@ -372,8 +378,9 @@ class ColBERT(LateInteractionModel):
         current_collection.extend(new_collection_for_indexer)
 
         if new_docid_metadata_map:
+            # current_docid_metadata_map is guaranteed to be a dict here
             current_docid_metadata_map.update(new_docid_metadata_map)
-
+        
         self.collections[index_name] = current_collection
         self.pid_docid_maps[index_name] = current_pid_docid_map
         self.docid_metadata_maps[index_name] = current_docid_metadata_map

--- a/ragatouille/server/server.py
+++ b/ragatouille/server/server.py
@@ -1,0 +1,170 @@
+import argparse
+from typing import List, Dict, Optional
+import os
+
+import batched
+import uvicorn
+from fastapi import FastAPI, HTTPException, APIRouter
+from pydantic import BaseModel
+from fastapi.responses import JSONResponse
+
+from ragatouille import RAGPretrainedModel
+
+app = FastAPI()
+
+class DocumentMetadata(BaseModel):
+    id: str
+    project_id: str
+
+class IndexRequest(BaseModel):
+    """PyDantic model for the requests sent to the server.
+
+    Parameters
+    ----------
+    input
+        The input(s) to encode.
+    metadata
+        The metadata of the quotes.
+    index_id
+        The id of the index.
+    """
+
+    input: List[str]
+    metadata: List[DocumentMetadata]
+    index_id: str
+
+
+class QueryRequest(BaseModel):
+    """PyDantic model for the requests sent to the server.
+
+    Parameters
+    ----------
+    input
+        The input(s) to encode.
+    index_id
+        The id of the index
+    """
+
+    input: List[str]
+    index_id: str
+    k: Optional[int] = 5
+
+
+class QueryResponse(BaseModel):
+    """PyDantic model for the server answer to a call.
+
+    Parameters
+    ----------
+    data
+        pass
+    model
+        The name of the model used for encoding.
+    """
+
+    data: List[List[Dict]]
+    model: str
+
+
+def wrap_encode_function(model, **kwargs):
+    def wrapped_encode(sentences):
+        return model.encode(sentences, **kwargs)
+
+    return wrapped_encode
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run FastAPI ColBERT serving server with specified host, port, and model."
+    )
+    parser.add_argument(
+        "--index_name",
+        type=str,
+        help="Index name to load",
+    )
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host to run the server on"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8002, help="Port to run the server on"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="jinaai/jina-colbert-v2",
+        help="Model to serve, can be an HF model or a path to a model",
+    )
+    parser.add_argument("--reload", action="store_true", help="Enable hot reload")
+
+    return parser.parse_args()
+
+
+args = parse_args()
+
+if args.reload:
+    os.environ["API_RELOAD"] = "true"
+    print("API_RELOAD enabled by --reload")
+
+# We need to load the model here so it is shared for every request
+model = RAGPretrainedModel.from_index(args.index_name)
+# We cannot create the function on the fly as the batching require to use the same function (memory address)
+# TODO still can't do this, especially if we will be separating indices by project_id.
+#model.search = batched.aio.dynamically(
+#    wrap_encode_function(model, is_query=True)
+#)
+#model.encode_document = batched.aio.dynamically(
+#    wrap_encode_function(model, is_query=False)
+#)
+
+router = APIRouter()
+
+@router.post("/index")
+async def index(request: IndexRequest):
+    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
+
+    Parameters
+    ----------
+    request
+        The IndexRequest
+    """
+    try:
+        model.add_to_index(
+            request.input
+        )
+        return JSONResponse(status_code=201, content={"result": "ok"})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/query", response_model=QueryResponse)
+async def query(request: QueryRequest):
+    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
+
+    Parameters
+    ----------
+    request
+        The QueryRequest
+    """
+    try:
+        if request.k is None:
+            k = 5
+        else:
+            k = request.k
+
+        docs = model.search(request.input, k=k)
+        if len(request.input) == 1:
+            print("Only 1 query, wrapping...")
+            docs = [docs]
+
+        return QueryResponse(
+            model="jinaai/jina-colbert-v2",
+            data=docs
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+app.include_router(router, prefix="/api/v1")
+
+if __name__ == "__main__":
+    reload = os.getenv("API_RELOAD", "false").lower() == "true"
+    module_path = "ragatouille.server.server:app"
+    uvicorn.run(module_path, host=args.host, port=args.port, reload=reload)

--- a/ragatouille/server/server.py
+++ b/ragatouille/server/server.py
@@ -2,7 +2,7 @@ import argparse
 from typing import List, Dict, Optional
 import os
 
-import batched
+# import batched # Batched processing is currently commented out
 import uvicorn
 from fastapi import FastAPI, HTTPException, APIRouter
 from pydantic import BaseModel
@@ -13,20 +13,20 @@ from ragatouille import RAGPretrainedModel
 app = FastAPI()
 
 class DocumentMetadata(BaseModel):
-    id: str
-    project_id: str
+    id: str # Unique ID for the original document
+    project_id: str # Example metadata field
 
 class IndexRequest(BaseModel):
-    """PyDantic model for the requests sent to the server.
+    """PyDantic model for the requests sent to the /index endpoint.
 
     Parameters
     ----------
     input
-        The input(s) to encode.
+        A list of document texts to be indexed.
     metadata
-        The metadata of the quotes.
+        A list of metadata objects, one for each document in `input`.
     index_id
-        The id of the index.
+        The identifier for the index to be created or updated.
     """
 
     input: List[str]
@@ -35,14 +35,16 @@ class IndexRequest(BaseModel):
 
 
 class QueryRequest(BaseModel):
-    """PyDantic model for the requests sent to the server.
+    """PyDantic model for the requests sent to the /query endpoint.
 
     Parameters
     ----------
     input
-        The input(s) to encode.
+        A list of query strings.
     index_id
-        The id of the index
+        The identifier of the index to query.
+    k
+        Optional number of results to return per query.
     """
 
     input: List[str]
@@ -51,49 +53,65 @@ class QueryRequest(BaseModel):
 
 
 class QueryResponse(BaseModel):
-    """PyDantic model for the server answer to a call.
+    """PyDantic model for the server answer to a /query call.
 
     Parameters
     ----------
     data
-        pass
+        List of search results. For multiple input queries, this will be a list of lists.
     model
-        The name of the model used for encoding.
+        The name of the base model used for encoding.
     """
 
-    data: List[List[Dict]]
+    data: List[List[Dict]] # Assuming search always returns a list of lists for multiple queries
     model: str
 
 
-def wrap_encode_function(model, **kwargs):
-    def wrapped_encode(sentences):
-        return model.encode(sentences, **kwargs)
-
-    return wrapped_encode
+# Batched processing currently not used with the single model refactor
+# def wrap_encode_function(model, **kwargs):
+#     def wrapped_encode(sentences):
+#         return model.encode(sentences, **kwargs)
+#     return wrapped_encode
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Run FastAPI ColBERT serving server with specified host, port, and model."
-    )
-    parser.add_argument(
-        "--index_name",
-        type=str,
-        help="Index name to load",
-    )
-    parser.add_argument(
-        "--host", type=str, default="0.0.0.0", help="Host to run the server on"
-    )
-    parser.add_argument(
-        "--port", type=int, default=8002, help="Port to run the server on"
+        description="Run FastAPI RAGatouille server with specified host, port, base model, and index root."
     )
     parser.add_argument(
         "--model",
         type=str,
         default="jinaai/jina-colbert-v2",
-        help="Model to serve, can be an HF model or a path to a model",
+        help="Base model to serve, can be an HF model name or a path to a local ColBERT checkpoint.",
     )
-    parser.add_argument("--reload", action="store_true", help="Enable hot reload")
+    parser.add_argument(
+        "--index-root",
+        dest="index_root",
+        type=str,
+        default="./ragatouille/colbert/indexes", # Default root directory for all indices
+        help="Root directory where all named indices will be stored and loaded from.",
+    )
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host to run the server on."
+    )
+    parser.add_argument(
+        "--port", type=int, default=8002, help="Port to run the server on."
+    )
+    parser.add_argument(
+        "--experiment-name",
+        dest="experiment_name",
+        type=str,
+        default="colbert",
+        help="Experiment name used in structuring index paths under index_root.",
+    )
+    parser.add_argument(
+        "--initial-index-name",
+        dest="initial_index_name",
+        type=str,
+        default=None,
+        help="Optional: Name of an index within index_root to pre-load at startup."
+    )
+    parser.add_argument("--reload", action="store_true", help="Enable hot reload for development.")
 
     return parser.parse_args()
 
@@ -102,69 +120,146 @@ args = parse_args()
 
 if args.reload:
     os.environ["API_RELOAD"] = "true"
-    print("API_RELOAD enabled by --reload")
+    print("API_RELOAD enabled by --reload flag.")
 
-# We need to load the model here so it is shared for every request
-model = RAGPretrainedModel.from_index(args.index_name)
-# We cannot create the function on the fly as the batching require to use the same function (memory address)
-# TODO still can't do this, especially if we will be separating indices by project_id.
-#model.search = batched.aio.dynamically(
-#    wrap_encode_function(model, is_query=True)
-#)
-#model.encode_document = batched.aio.dynamically(
-#    wrap_encode_function(model, is_query=False)
-#)
+# Load the single RAGPretrainedModel instance
+# This model instance will manage multiple indices under args.index_root
+try:
+    print(f"Loading RAGPretrainedModel with base model: {args.model}")
+    print(f"Index root set to: {args.index_root}")
+    if args.initial_index_name:
+        print(f"Attempting to pre-load initial index: {args.initial_index_name}")
+
+    model = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=args.model,
+        index_root=args.index_root,
+        initial_index_name=args.initial_index_name,
+        experiment_name=args.experiment_name,
+        # Add other RAGPretrainedModel.from_pretrained parameters if needed (e.g., n_gpu, verbose)
+    )
+    print("RAGPretrainedModel loaded successfully.")
+except Exception as e:
+    print(f"Error loading RAGPretrainedModel: {e}")
+    # Depending on server resilience requirements, you might exit or try to run degraded
+    raise RuntimeError(f"Failed to initialize RAGPretrainedModel: {e}") from e
+
 
 router = APIRouter()
 
-@router.post("/index")
-async def index(request: IndexRequest):
-    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
-
-    Parameters
-    ----------
-    request
-        The IndexRequest
+@router.post("/index/create")
+async def create_index(request: IndexRequest):
+    """
+    API endpoint to index a list of documents.
+    If the index_id does not exist, a new index will be created.
+    If it exists, behavior depends on the underlying ColBERT index overwrite policy (default "reuse").
     """
     try:
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input documents list cannot be empty.")
+        if len(request.input) != len(request.metadata):
+            raise HTTPException(status_code=400, detail="Length of input documents and metadata must match.")
+
+        document_ids = [meta.id for meta in request.metadata]
+        # Ensure document_ids are unique as RAGPretrainedModel expects this
+        if len(document_ids) != len(set(document_ids)):
+            raise HTTPException(status_code=400, detail="Document IDs in metadata must be unique.")
+
+        document_metadatas = [{"project_id": meta.project_id} for meta in request.metadata]
+
+        print(f"Indexing documents for index_id: {request.index_id}...")
+        # RAGPretrainedModel.index will handle splitting and creating ColBERT index
+        # Overwrite policy is handled by ColBERT (default "reuse")
+        index_path = model.index(
+            index_name=request.index_id,
+            documents=request.input,
+            document_ids=document_ids,
+            document_metadatas=document_metadatas,
+            # max_document_length, bsize, use_faiss_index can be exposed or configured as needed
+        )
+        print(f"Documents indexed for index_id: {request.index_id}. Index path: {index_path}")
+        return JSONResponse(status_code=201, content={"result": "ok", "index_path": index_path})
+    except ValueError as ve: # Catch specific errors like ID mismatches from RAGatouille
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        print(f"Error during indexing for index_id {request.index_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/index/add")
+async def add_to_index(request: IndexRequest):
+    """
+    API endpoint to index a list of documents.
+    If the index_id does not exist, a new index will be created.
+    If it exists, behavior depends on the underlying ColBERT index overwrite policy (default "reuse").
+    """
+    try:
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input documents list cannot be empty.")
+        if len(request.input) != len(request.metadata):
+            raise HTTPException(status_code=400, detail="Length of input documents and metadata must match.")
+
+        document_ids = [meta.id for meta in request.metadata]
+        # Ensure document_ids are unique as RAGPretrainedModel expects this
+        if len(document_ids) != len(set(document_ids)):
+            raise HTTPException(status_code=400, detail="Document IDs in metadata must be unique.")
+
+        document_metadatas = [{"project_id": meta.project_id} for meta in request.metadata]
+
+        print(f"Indexing documents for index_id: {request.index_id}...")
         model.add_to_index(
-            request.input
+            index_name=request.index_id,
+            new_documents=request.input,
+            new_document_ids=document_ids,
+            new_document_metadatas=document_metadatas,
         )
         return JSONResponse(status_code=201, content={"result": "ok"})
+    except ValueError as ve: # Catch specific errors like ID mismatches from RAGatouille
+        raise HTTPException(status_code=400, detail=str(ve))
     except Exception as e:
+        print(f"Error during indexing for index_id {request.index_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/query", response_model=QueryResponse)
-async def query(request: QueryRequest):
-    """API endpoint that encode the elements of an EmbeddingRequest and returns an EmbeddingResponse.
-
-    Parameters
-    ----------
-    request
-        The QueryRequest
+async def query_index(request: QueryRequest):
+    """
+    API endpoint to query an index.
     """
     try:
-        if request.k is None:
-            k = 5
-        else:
-            k = request.k
+        if not request.input:
+            raise HTTPException(status_code=400, detail="Input query list cannot be empty.")
 
-        docs = model.search(request.input, k=k)
-        if len(request.input) == 1:
-            print("Only 1 query, wrapping...")
-            docs = [docs]
+        k_val = request.k if request.k is not None else 5 # Default k if not provided
 
-        return QueryResponse(
-            model="jinaai/jina-colbert-v2",
-            data=docs
+        print(f"Querying index_id: {request.index_id} with k={k_val}...")
+        # RAGPretrainedModel.search handles loading the correct index context
+        search_results = model.search(
+            index_name=request.index_id,
+            query=request.input,
+            k=k_val
         )
+
+        # Ensure results are always a list of lists, even for a single query
+        if len(request.input) == 1 and not isinstance(search_results[0], list):
+            final_results = [search_results]
+        else:
+            final_results = search_results
+
+        print(f"Query successful for index_id: {request.index_id}.")
+        return QueryResponse(
+            model=model.get_model().base_pretrained_model_name_or_path, # Get base model name
+            data=final_results
+        )
+    except FileNotFoundError as fnfe: # Specific error if index doesn't exist for querying
+        print(f"Index not found for query: {request.index_id}. Error: {fnfe}")
+        raise HTTPException(status_code=404, detail=f"Index '{request.index_id}' not found.")
     except Exception as e:
+        print(f"Error during query for index_id {request.index_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 app.include_router(router, prefix="/api/v1")
 
 if __name__ == "__main__":
-    reload = os.getenv("API_RELOAD", "false").lower() == "true"
-    module_path = "ragatouille.server.server:app"
-    uvicorn.run(module_path, host=args.host, port=args.port, reload=reload)
+    is_reload = os.getenv("API_RELOAD", "false").lower() == "true"
+    module_path = "ragatouille.server.server:app" # Standard for uvicorn
+    uvicorn.run(module_path, host=args.host, port=args.port, reload=is_reload)

--- a/tests/e2e/test_e2e_indexing_searching.py
+++ b/tests/e2e/test_e2e_indexing_searching.py
@@ -1,91 +1,118 @@
 import pytest
 import srsly
+import os
+from pathlib import Path
 
 from ragatouille import RAGPretrainedModel
 from ragatouille.utils import get_wikipedia_page
 
+# Define a common index root for the test session using pytest's tmp_path_factory
+@pytest.fixture(scope="session")
+def session_index_root(tmp_path_factory):
+    return tmp_path_factory.mktemp("ragatouille_e2e_tests_root")
 
-def test_indexing():
-    RAG = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")
+@pytest.fixture(scope="session")
+def model_name():
+    return "colbert-ir/colbertv2.0" # Or a smaller test model if available
+
+@pytest.fixture(scope="session")
+def experiment_name():
+    return "colbert" # Keep test experiments separate
+
+@pytest.fixture(scope="session")
+def miyazaki_index_name():
+    return "Miyazaki"
+
+@pytest.fixture(scope="session")
+def miyazaki_index_path(session_index_root, experiment_name, miyazaki_index_name):
+    return Path(session_index_root) / experiment_name / "indexes" / miyazaki_index_name
+
+@pytest.fixture(scope="session")
+def rag_model_for_indexing(model_name, session_index_root, experiment_name):
+    """RAG model instance for indexing tests."""
+    return RAGPretrainedModel.from_pretrained(
+        model_name,
+        index_root=str(session_index_root),
+        experiment_name=experiment_name
+    )
+
+def test_indexing(rag_model_for_indexing, miyazaki_index_name, miyazaki_index_path):
+    RAG = rag_model_for_indexing
     with open("tests/data/miyazaki_wikipedia.txt", "r") as f:
         full_document = f.read()
+
+    # RAG.index now takes 'documents' and 'document_ids'
+    # 'split_documents' is handled by the CorpusProcessor inside RAGPretrainedModel
+    # 'max_document_length' is used as chunk_size for the default splitter
     RAG.index(
-        collection=[full_document],
-        index_name="Miyazaki",
+        index_name=miyazaki_index_name,
+        documents=[full_document],
+        document_ids=["miyazaki_doc_1"], # Must provide document_ids
         max_document_length=180,
-        split_documents=True,
     )
     # ensure collection is stored to disk
-    collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
+    collection_path = miyazaki_index_path / "collection.json"
+    assert collection_path.exists(), f"Collection file not found at {collection_path}"
+    collection = srsly.read_json(str(collection_path))
+    assert len(collection) > 1, "Collection should have more than one chunk"
+
+
+def test_search(model_name, miyazaki_index_name, miyazaki_index_path):
+    # Ensure the index exists from test_indexing
+    assert miyazaki_index_path.exists(), f"Index path {miyazaki_index_path} must exist from a previous indexing step."
+
+    # from_index now also requires pretrained_model_name_or_path
+    RAG = RAGPretrainedModel.from_index(
+        index_path=str(miyazaki_index_path),
+        pretrained_model_name_or_path=model_name
     )
-    assert len(collection) > 1
-
-
-def test_search():
-    RAG = RAGPretrainedModel.from_index(".ragatouille/colbert/indexes/Miyazaki/")
-    k = 3  # How many documents you want to retrieve, defaults to 10, we set it to 3 here for readability
-    results = RAG.search(query="What animation studio did Miyazaki found?", k=k)
+    k = 3
+    # search now requires index_name
+    results = RAG.search(index_name=miyazaki_index_name, query="What animation studio did Miyazaki found?", k=k)
     assert len(results) == k
-    assert (
-        "In April 1984, Miyazaki opened his own office in Suginami Ward"
-        in results[0]["content"]
-    )
-    assert (
-        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
-        in results[1]["content"]
-    )
-    assert (
-        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
-        in results[2]["content"]
-    )
+    # Content assertions can be brittle, checking for presence is okay
+    assert "Studio Ghibli" in results[0]["content"] or "Nibariki" in results[0]["content"]
 
     all_results = RAG.search(
+        index_name=miyazaki_index_name,
         query=["What animation studio did Miyazaki found?", "Miyazaki son name"], k=k
     )
-    assert (
-        "In April 1984, Miyazaki opened his own office in Suginami Ward"
-        in all_results[0][0]["content"]
-    )
-    assert (
-        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
-        in all_results[0][1]["content"]
-    )
-    assert (
-        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
-        in all_results[0][2]["content"]
-    )
-    assert (
-        "== Early life ==\nHayao Miyazaki was born on January 5, 1941"
-        in all_results[1][0]["content"]  # noqa
-    )
-    assert (
-        "Directed by Isao Takahata, with whom Miyazaki would continue to collaborate for the remainder of his career"  # noqa
-        in all_results[1][1]["content"]
-    )
-    actual = all_results[1][2]["content"]
-    assert (
-        "Specific works that have influenced Miyazaki include Animal Farm (1945)"
-        in actual
-        or "She met with Suzuki" in actual
-    )
+    assert len(all_results) == 2
+    assert len(all_results[0]) == k
+    assert len(all_results[1]) == k
+    assert "Studio Ghibli" in all_results[0][0]["content"] or "Nibariki" in all_results[0][0]["content"]
+    assert "Goro" in all_results[1][0]["content"] or "Keisuke" in all_results[1][0]["content"]
     print(all_results)
 
 
-@pytest.mark.skip(reason="experimental feature.")
-def test_basic_CRUD_addition():
-    old_collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
-    )
+@pytest.mark.skip(reason="experimental feature, needs careful review of add_to_index impact on existing data.")
+def test_basic_CRUD_addition(model_name, miyazaki_index_name, miyazaki_index_path):
+    assert miyazaki_index_path.exists(), f"Index path {miyazaki_index_path} must exist from a previous indexing step."
+    collection_path = miyazaki_index_path / "collection.json"
+
+    old_collection = srsly.read_json(str(collection_path))
     old_collection_len = len(old_collection)
-    path_to_index = ".ragatouille/colbert/indexes/Miyazaki/"
-    RAG = RAGPretrainedModel.from_index(path_to_index)
 
-    new_documents = get_wikipedia_page("Studio_Ghibli")
-
-    RAG.add_to_index([new_documents])
-    new_collection = srsly.read_json(
-        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
+    RAG = RAGPretrainedModel.from_index(
+        index_path=str(miyazaki_index_path),
+        pretrained_model_name_or_path=model_name
     )
+
+    new_document_text = get_wikipedia_page("Studio_Ghibli") # Assuming this returns a single string
+
+    # add_to_index requires index_name, new_documents (list of strings), and new_document_ids (list of strings)
+    RAG.add_to_index(
+        index_name=miyazaki_index_name,
+        new_documents=[new_document_text],
+        new_document_ids=["studio_ghibli_doc_CRUD"] # Provide a unique ID for the new document
+    )
+
+    new_collection = srsly.read_json(str(collection_path))
     assert len(new_collection) > old_collection_len
-    assert len(new_collection) == 140
+    # The exact number of chunks (like 140) can be very specific and brittle.
+    # It's better to assert that the collection grew and that content from the new doc is searchable.
+
+    # Optional: Verify new content is searchable
+    results = RAG.search(index_name=miyazaki_index_name, query="Tokuma Shoten", k=1)
+    assert len(results) > 0
+    assert "Tokuma Shoten" in results[0]["content"]

--- a/tests/e2e/test_e2e_indexing_searching.py
+++ b/tests/e2e/test_e2e_indexing_searching.py
@@ -49,6 +49,7 @@ def test_indexing(rag_model_for_indexing, miyazaki_index_name, miyazaki_index_pa
         documents=[full_document],
         document_ids=["miyazaki_doc_1"], # Must provide document_ids
         max_document_length=180,
+        split_documents=True
     )
     # ensure collection is stored to disk
     collection_path = miyazaki_index_path / "collection.json"
@@ -70,18 +71,50 @@ def test_search(model_name, miyazaki_index_name, miyazaki_index_path):
     # search now requires index_name
     results = RAG.search(index_name=miyazaki_index_name, query="What animation studio did Miyazaki found?", k=k)
     assert len(results) == k
-    # Content assertions can be brittle, checking for presence is okay
-    assert "Studio Ghibli" in results[0]["content"] or "Nibariki" in results[0]["content"]
+    assert (
+        "In April 1984, Miyazaki opened his own office in Suginami Ward"
+        in results[0]["content"]
+    )
+    assert (
+        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
+        in results[1]["content"]
+    )
+    assert (
+        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
+        in results[2]["content"]
+    )
 
     all_results = RAG.search(
         index_name=miyazaki_index_name,
-        query=["What animation studio did Miyazaki found?", "Miyazaki son name"], k=k
+        query=["What animation studio did Miyazaki found?", "Miyazaki son name"],
+        k=k
     )
-    assert len(all_results) == 2
-    assert len(all_results[0]) == k
-    assert len(all_results[1]) == k
-    assert "Studio Ghibli" in all_results[0][0]["content"] or "Nibariki" in all_results[0][0]["content"]
-    assert "Goro" in all_results[1][0]["content"] or "Keisuke" in all_results[1][0]["content"]
+    assert (
+        "In April 1984, Miyazaki opened his own office in Suginami Ward"
+        in all_results[0][0]["content"]
+    )
+    assert (
+        "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941)"  # noqa
+        in all_results[0][1]["content"]
+    )
+    assert (
+        'Glen Keane said Miyazaki is a "huge influence" on Walt Disney Animation Studios and has been'  # noqa
+        in all_results[0][2]["content"]
+    )
+    assert (
+        "== Early life ==\nHayao Miyazaki was born on January 5, 1941"
+        in all_results[1][0]["content"]  # noqa
+    )
+    assert (
+        "Directed by Isao Takahata, with whom Miyazaki would continue to collaborate for the remainder of his career"  # noqa
+        in all_results[1][1]["content"]
+    )
+    actual = all_results[1][2]["content"]
+    assert (
+        "Specific works that have influenced Miyazaki include Animal Farm (1945)"
+        in actual
+        or "She met with Suzuki" in actual
+    )
     print(all_results)
 
 
@@ -98,20 +131,16 @@ def test_basic_CRUD_addition(model_name, miyazaki_index_name, miyazaki_index_pat
         pretrained_model_name_or_path=model_name
     )
 
-    new_document_text = get_wikipedia_page("Studio_Ghibli") # Assuming this returns a single string
+    new_document_text = get_wikipedia_page("Studio_Ghibli")
 
-    # add_to_index requires index_name, new_documents (list of strings), and new_document_ids (list of strings)
     RAG.add_to_index(
         index_name=miyazaki_index_name,
         new_documents=[new_document_text],
-        new_document_ids=["studio_ghibli_doc_CRUD"] # Provide a unique ID for the new document
+        new_document_ids=["studio_ghibli_doc_CRUD"]
     )
 
     new_collection = srsly.read_json(str(collection_path))
     assert len(new_collection) > old_collection_len
-    # The exact number of chunks (like 140) can be very specific and brittle.
-    # It's better to assert that the collection grew and that content from the new doc is searchable.
-
     # Optional: Verify new content is searchable
     results = RAG.search(index_name=miyazaki_index_name, query="Tokuma Shoten", k=1)
     assert len(results) > 0

--- a/tests/test_pretrained_loading.py
+++ b/tests/test_pretrained_loading.py
@@ -1,16 +1,102 @@
 import pytest
+import shutil
+from pathlib import Path
+from ragatouille import RAGPretrainedModel
+
+# Constants for tests
+PRETRAINED_MODEL_FOR_LOADING_TESTS = "colbert-ir/colbertv2.0" # Using a real, small model
+# Alternative for faster tests if available: "hf-internal-testing/tiny-bert-colbert" - but this might not work with ColBERT logic directly
+TEST_EXPERIMENT_LOADING = "ragatouille_loading_tests"
+
+@pytest.fixture(scope="session")
+def loading_test_index_root(tmp_path_factory):
+    """Creates a session-wide temporary root directory for indices created during loading tests."""
+    path = tmp_path_factory.mktemp("loading_tests_indices")
+    yield str(path)
+    shutil.rmtree(path, ignore_errors=True) # Clean up after all tests in session
+
+def test_from_pretrained_loads_model(loading_test_index_root):
+    """Tests if RAGPretrainedModel.from_pretrained successfully loads the underlying ColBERT model."""
+    rag_instance = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
+        index_root=loading_test_index_root,
+        experiment_name=TEST_EXPERIMENT_LOADING,
+        verbose=0
+    )
+    assert isinstance(rag_instance, RAGPretrainedModel), "Should return a RAGPretrainedModel instance."
+    assert rag_instance.model is not None, "Internal ColBERT model should be initialized."
+    assert hasattr(rag_instance.model, 'inference_ckpt'), "ColBERT model should have an inference_ckpt."
+    assert rag_instance.model.inference_ckpt is not None, "inference_ckpt should be loaded."
+    assert rag_instance.model.base_pretrained_model_name_or_path == PRETRAINED_MODEL_FOR_LOADING_TESTS
+
+def test_from_index_loads_model_and_specific_index(loading_test_index_root):
+    """
+    Tests if RAGPretrainedModel.from_index can load a model and correctly
+    initialize with the specified index.
+    """
+    index_name_for_test = "my_loading_test_index"
+    documents_for_index = ["This is a test document for loading from index."]
+    doc_ids_for_index = ["test_doc_loader_01"]
+
+    # Step 1: Create an index to load from
+    rag_for_creation = RAGPretrainedModel.from_pretrained(
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
+        index_root=loading_test_index_root,
+        experiment_name=TEST_EXPERIMENT_LOADING,
+        verbose=0
+    )
+    created_index_path_str = rag_for_creation.index(
+        index_name=index_name_for_test,
+        documents=documents_for_index,
+        document_ids=doc_ids_for_index,
+        overwrite_index=True
+    )
+    created_index_path = Path(created_index_path_str)
+    assert created_index_path.exists(), "Index directory for loading test was not created."
+
+    # Step 2: Load from the created index
+    rag_loaded_from_index = RAGPretrainedModel.from_index(
+        index_path=str(created_index_path),
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS, # Crucial for new API
+        verbose=0
+    )
+
+    assert isinstance(rag_loaded_from_index, RAGPretrainedModel), "from_index should return RAGPretrainedModel."
+    assert rag_loaded_from_index.model is not None, "Internal ColBERT model should be initialized via from_index."
+    assert hasattr(rag_loaded_from_index.model, 'inference_ckpt'), "ColBERT model (from_index) should have inference_ckpt."
+    assert rag_loaded_from_index.model.inference_ckpt is not None, "inference_ckpt (from_index) should be loaded."
+
+    # Check if the ColBERT model correctly identifies the initially loaded index
+    # The 'initial_index_name' is set in ColBERT.__init__ if an index is loaded at startup.
+    # from_index in RAGPretrainedModel passes the inferred index name as 'initial_index_name'
+    # to from_pretrained, which then passes it to ColBERT.
+    assert rag_loaded_from_index.model.index_configs.get(index_name_for_test) is not None, \
+        f"Index '{index_name_for_test}' config not found in loaded model."
+    
+    # Verify the model's index_root and experiment_name are correctly set through from_index logic
+    expected_index_root = str(created_index_path.parent.parent.parent) # index_root/experiment/indexes/index_name
+    assert rag_loaded_from_index.model.index_root == expected_index_root
+    assert rag_loaded_from_index.model.experiment_name == TEST_EXPERIMENT_LOADING
 
 
-@pytest.mark.skip(reason="NotImplemented")
-def test_from_checkpoint():
-    pass
+    # Step 3: Perform a simple search to ensure the loaded index is active and usable
+    search_query = "test document"
+    results = rag_loaded_from_index.search(
+        index_name=index_name_for_test,
+        query=search_query,
+        k=1
+    )
+    assert isinstance(results, list), "Search should return a list."
+    if documents_for_index: # If we actually indexed something
+        assert len(results) > 0, "Search returned no results on a supposedly loaded index."
+        assert results[0]["document_id"] == doc_ids_for_index[0], "Search did not retrieve the correct document."
 
-
-@pytest.mark.skip(reason="NotImplemented")
-def test_from_index():
-    pass
-
-
-@pytest.mark.skip(reason="NotImplemented")
+@pytest.mark.skip(reason="Test intent unclear or needs refactoring for current API. Covered by other e2e search tests.")
 def test_searcher():
+    """
+    This test was originally skipped and its intent regarding 'searcher' properties
+    is not directly testable via RAGPretrainedModel's public API in a meaningful way
+    beyond what `test_search` in e2e tests or `test_from_index_loads_model_and_index` cover.
+    The internal `Searcher` object management is an implementation detail of `ColBERT` and `ModelIndex`.
+    """
     pass

--- a/tests/test_pretrained_loading.py
+++ b/tests/test_pretrained_loading.py
@@ -1,102 +1,16 @@
 import pytest
-import shutil
-from pathlib import Path
-from ragatouille import RAGPretrainedModel
-
-# Constants for tests
-PRETRAINED_MODEL_FOR_LOADING_TESTS = "colbert-ir/colbertv2.0" # Using a real, small model
-# Alternative for faster tests if available: "hf-internal-testing/tiny-bert-colbert" - but this might not work with ColBERT logic directly
-TEST_EXPERIMENT_LOADING = "ragatouille_loading_tests"
-
-@pytest.fixture(scope="session")
-def loading_test_index_root(tmp_path_factory):
-    """Creates a session-wide temporary root directory for indices created during loading tests."""
-    path = tmp_path_factory.mktemp("loading_tests_indices")
-    yield str(path)
-    shutil.rmtree(path, ignore_errors=True) # Clean up after all tests in session
-
-def test_from_pretrained_loads_model(loading_test_index_root):
-    """Tests if RAGPretrainedModel.from_pretrained successfully loads the underlying ColBERT model."""
-    rag_instance = RAGPretrainedModel.from_pretrained(
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
-        index_root=loading_test_index_root,
-        experiment_name=TEST_EXPERIMENT_LOADING,
-        verbose=0
-    )
-    assert isinstance(rag_instance, RAGPretrainedModel), "Should return a RAGPretrainedModel instance."
-    assert rag_instance.model is not None, "Internal ColBERT model should be initialized."
-    assert hasattr(rag_instance.model, 'inference_ckpt'), "ColBERT model should have an inference_ckpt."
-    assert rag_instance.model.inference_ckpt is not None, "inference_ckpt should be loaded."
-    assert rag_instance.model.base_pretrained_model_name_or_path == PRETRAINED_MODEL_FOR_LOADING_TESTS
-
-def test_from_index_loads_model_and_specific_index(loading_test_index_root):
-    """
-    Tests if RAGPretrainedModel.from_index can load a model and correctly
-    initialize with the specified index.
-    """
-    index_name_for_test = "my_loading_test_index"
-    documents_for_index = ["This is a test document for loading from index."]
-    doc_ids_for_index = ["test_doc_loader_01"]
-
-    # Step 1: Create an index to load from
-    rag_for_creation = RAGPretrainedModel.from_pretrained(
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS,
-        index_root=loading_test_index_root,
-        experiment_name=TEST_EXPERIMENT_LOADING,
-        verbose=0
-    )
-    created_index_path_str = rag_for_creation.index(
-        index_name=index_name_for_test,
-        documents=documents_for_index,
-        document_ids=doc_ids_for_index,
-        overwrite_index=True
-    )
-    created_index_path = Path(created_index_path_str)
-    assert created_index_path.exists(), "Index directory for loading test was not created."
-
-    # Step 2: Load from the created index
-    rag_loaded_from_index = RAGPretrainedModel.from_index(
-        index_path=str(created_index_path),
-        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_LOADING_TESTS, # Crucial for new API
-        verbose=0
-    )
-
-    assert isinstance(rag_loaded_from_index, RAGPretrainedModel), "from_index should return RAGPretrainedModel."
-    assert rag_loaded_from_index.model is not None, "Internal ColBERT model should be initialized via from_index."
-    assert hasattr(rag_loaded_from_index.model, 'inference_ckpt'), "ColBERT model (from_index) should have inference_ckpt."
-    assert rag_loaded_from_index.model.inference_ckpt is not None, "inference_ckpt (from_index) should be loaded."
-
-    # Check if the ColBERT model correctly identifies the initially loaded index
-    # The 'initial_index_name' is set in ColBERT.__init__ if an index is loaded at startup.
-    # from_index in RAGPretrainedModel passes the inferred index name as 'initial_index_name'
-    # to from_pretrained, which then passes it to ColBERT.
-    assert rag_loaded_from_index.model.index_configs.get(index_name_for_test) is not None, \
-        f"Index '{index_name_for_test}' config not found in loaded model."
-    
-    # Verify the model's index_root and experiment_name are correctly set through from_index logic
-    expected_index_root = str(created_index_path.parent.parent.parent) # index_root/experiment/indexes/index_name
-    assert rag_loaded_from_index.model.index_root == expected_index_root
-    assert rag_loaded_from_index.model.experiment_name == TEST_EXPERIMENT_LOADING
 
 
-    # Step 3: Perform a simple search to ensure the loaded index is active and usable
-    search_query = "test document"
-    results = rag_loaded_from_index.search(
-        index_name=index_name_for_test,
-        query=search_query,
-        k=1
-    )
-    assert isinstance(results, list), "Search should return a list."
-    if documents_for_index: # If we actually indexed something
-        assert len(results) > 0, "Search returned no results on a supposedly loaded index."
-        assert results[0]["document_id"] == doc_ids_for_index[0], "Search did not retrieve the correct document."
+@pytest.mark.skip(reason="NotImplemented")
+def test_from_checkpoint():
+    pass
 
-@pytest.mark.skip(reason="Test intent unclear or needs refactoring for current API. Covered by other e2e search tests.")
+
+@pytest.mark.skip(reason="NotImplemented")
+def test_from_index():
+    pass
+
+
+@pytest.mark.skip(reason="NotImplemented")
 def test_searcher():
-    """
-    This test was originally skipped and its intent regarding 'searcher' properties
-    is not directly testable via RAGPretrainedModel's public API in a meaningful way
-    beyond what `test_search` in e2e tests or `test_from_index_loads_model_and_index` cover.
-    The internal `Searcher` object management is an implementation detail of `ColBERT` and `ModelIndex`.
-    """
     pass

--- a/tests/test_pretrained_optional_args.py
+++ b/tests/test_pretrained_optional_args.py
@@ -1,283 +1,374 @@
 import os
 import shutil
-from pathlib import Path
 
 import pytest
 import srsly
 
 from ragatouille import RAGPretrainedModel
 
-# Sample data for tests
-COLLECTION_SAMPLES = [
-    "Hayao Miyazaki is a Japanese animator, filmmaker, and manga artist. He co-founded Studio Ghibli.",
-    "Studio Ghibli, Inc. is a Japanese animation studio based in Koganei, Tokyo. Its mascot is Totoro.",
-    "Princess Mononoke is a 1997 Japanese animated epic historical fantasy film by Studio Ghibli.",
+# Original global sample data
+collection_samples = [
+    "Hayao Miyazaki (宮崎 駿 or 宮﨑 駿, Miyazaki Hayao, [mijaꜜzaki hajao]; born January 5, 1941) is a Japanese animator, filmmaker, and manga artist. A co-founder of Studio Ghibli, he has attained international acclaim as a masterful storyteller and creator of Japanese animated feature films, and is widely regarded as one of the most accomplished filmmakers in the history of animation.\nBorn in Tokyo City in the Empire of Japan, Miyazaki expressed interest in manga and animation from an early age, and he joined Toei Animation in 1963. During his early years at Toei Animation he worked as an in-between artist and later collaborated with director Isao Takahata. Notable films to which Miyazaki contributed at Toei include Doggie March and Gulliver's Travels Beyond the Moon. He provided key animation to other films at Toei, such as Puss in Boots and Animal Treasure Island, before moving to A-Pro in 1971, where he co-directed Lupin the Third Part I alongside Takahata. After moving to Zuiyō Eizō (later known as Nippon Animation) in 1973, Miyazaki worked as an animator on World Masterpiece Theater, and directed the television series Future Boy Conan (1978). He joined Tokyo Movie Shinsha in 1979 to direct his first feature film The Castle of Cagliostro as well as the television series Sherlock Hound. In the same period, he also began writing and illustrating the manga Nausicaä of the Valley of the Wind (1982–1994), and he also directed the 1984 film adaptation produced by Topcraft.\nMiyazaki co-founded Studio Ghibli in 1985. He directed numerous films with Ghibli, including Laputa: Castle in the Sky (1986), My Neighbor Totoro (1988), Kiki's Delivery Service (1989), and Porco Rosso (1992). The films were met with critical and commercial success in Japan. Miyazaki's film Princess Mononoke was the first animated film ever to win the Japan Academy Prize for Picture of the Year, and briefly became the highest-grossing film in Japan following its release in 1997; its distribution to the Western world greatly increased Ghibli's popularity and influence outside Japan. His 2001 film Spirited Away became the highest-grossing film in Japanese history, winning the Academy Award for Best Animated Feature, and is frequently ranked among the greatest films of the 21st century. Miyazaki's later films—Howl's Moving Castle (2004), Ponyo (2008), and The Wind Rises (2013)—also enjoyed critical and commercial success.",
+    "Studio Ghibli, Inc. (Japanese: 株式会社スタジオジブリ, Hepburn: Kabushiki gaisha Sutajio Jiburi) is a Japanese animation studio based in Koganei, Tokyo. It has a strong presence in the animation industry and has expanded its portfolio to include various media formats, such as short subjects, television commercials, and two television films. Their work has been well-received by audiences and recognized with numerous awards. Their mascot and most recognizable symbol, the character Totoro from the 1988 film My Neighbor Totoro, is a giant spirit inspired by raccoon dogs (tanuki) and cats (neko). Among the studio's highest-grossing films are Spirited Away (2001), Howl's Moving Castle (2004), and Ponyo (2008). Studio Ghibli was founded on June 15, 1985, by the directors Hayao Miyazaki and Isao Takahata and producer Toshio Suzuki, after acquiring Topcraft's assets. The studio has also collaborated with video game studios on the visual development of several games.Five of the studio's films are among the ten highest-grossing anime feature films made in Japan. Spirited Away is second, grossing 31.68 billion yen in Japan and over US$380 million worldwide, and Princess Mononoke is fourth, grossing 20.18 billion yen. Three of their films have won the Animage Grand Prix award, four have won the Japan Academy Prize for Animation of the Year, and five have received Academy Award nominations. Spirited Away won the 2002 Golden Bear and the 2003 Academy Award for Best Animated Feature.On August 3, 2014, Studio Ghibli temporarily suspended production following Miyazaki's retirement.",
 ]
 
-DOCUMENT_IDS_SAMPLES = ["miyazaki_bio", "ghibli_info", "mononoke_film"]
+document_ids_samples = ["miyazaki", "ghibli"]
 
-DOCUMENT_METADATAS_SAMPLES = [
-    {"entity": "person", "source": "wikipedia", "year": 1941},
-    {"entity": "organisation", "source": "wikipedia", "founded": 1985},
-    {"entity": "film", "source": "wikipedia", "release_year": 1997},
+document_metadatas_samples = [
+    {"entity": "person", "source": "wikipedia"},
+    {"entity": "organisation", "source": "wikipedia"},
 ]
 
-# Use a fixed model name for tests for consistency
-PRETRAINED_MODEL_NAME = "colbert-ir/colbertv2.0"
-TEST_EXPERIMENT_NAME = "ragatouille_test_suite_optional_args"
-
+PRETRAINED_MODEL_FOR_TESTS = "colbert-ir/colbertv2.0"
+DEFAULT_EXPERIMENT_NAME = "colbert" # To match original path structure
 
 @pytest.fixture(scope="session")
-def persistent_test_index_root(tmp_path_factory):
-    # Creates a temporary root directory for all indices for the test session
-    path = tmp_path_factory.mktemp("ragatouille_test_indices_root_optional_args")
+def persistent_temp_index_root(tmp_path_factory):
+    path = tmp_path_factory.mktemp("temp_test_indexes_optional_args")
     yield str(path)
-    # Cleanup after session
-    shutil.rmtree(path, ignore_errors=True)
+    # Cleanup is handled by pytest tmp_path_factory for session-scoped fixtures
 
-
-@pytest.fixture(scope="module")  # One RAG model instance per test module (this file)
-def rag_model_instance(persistent_test_index_root):
+@pytest.fixture(scope="session")
+def RAG_from_pretrained_model_fixture(persistent_temp_index_root):
+    # Pass experiment_name to maintain original path structure if tests relied on it
     return RAGPretrainedModel.from_pretrained(
-        PRETRAINED_MODEL_NAME,
-        index_root=persistent_test_index_root,
-        experiment_name=TEST_EXPERIMENT_NAME,
-        verbose=0  # Keep test output clean
+        PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        experiment_name=DEFAULT_EXPERIMENT_NAME,
+        verbose=0
     )
 
-
-# Parameterize test cases for different combinations of inputs to RAG.index()
-INDEX_CREATION_PARAMS = [
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:1],
-            "document_ids": None, # Test auto-generation
-            "document_metadatas": None,
-            "index_name_suffix": "no_opts_auto_ids",
-            "max_document_length": 128,
-        },
-        id="no_optional_args_auto_ids",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:1],
-            "document_ids": DOCUMENT_IDS_SAMPLES[:1],
-            "document_metadatas": None,
-            "index_name_suffix": "with_docid",
-            "max_document_length": 512, # Simulate no splitting
-        },
-        id="with_doc_ids_no_split",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES[:2],
-            "document_ids": DOCUMENT_IDS_SAMPLES[:2],
-            "document_metadatas": DOCUMENT_METADATAS_SAMPLES[:2],
-            "index_name_suffix": "with_docid_meta",
-            "max_document_length": 64, # Simulate splitting
-        },
-        id="with_doc_ids_metadata_split",
-    ),
-    pytest.param(
-        {
-            "documents": COLLECTION_SAMPLES,
-            "document_ids": DOCUMENT_IDS_SAMPLES,
-            "document_metadatas": DOCUMENT_METADATAS_SAMPLES,
-            "index_name_suffix": "all_docs_all_details",
-            "max_document_length": 128,
-        },
-        id="all_docs_all_details_split",
-    ),
-]
-
-
-@pytest.fixture(scope="function", params=INDEX_CREATION_PARAMS)
-def index_params_for_function(request, rag_model_instance):
-    # Generates a unique index name for each parameterized test function run
-    base_params = request.param.copy()
-    # Create a unique index name based on test name and params
-    # to ensure isolation even if tests run in parallel within the module (though pytest usually serializes by default)
-    unique_suffix = request.node.name.replace("test_", "").replace("[", "_").replace("]", "")
-    base_params["index_name"] = f"test_idx_{base_params['index_name_suffix']}_{unique_suffix}"
-
-    # Ensure document_ids are correctly handled for RAG.index()
-    # If document_ids is None in params, RAGPretrainedModel will auto-generate them.
-    # Store the effective document_ids used for assertion later.
-    if base_params["document_ids"] is None:
-        # RAGPretrainedModel generates UUIDs if None is passed.
-        # We can't know them in advance for assertion against pid_docid_map values exactly,
-        # but we can check counts and that metadata aligns if generated.
-        # For simplicity in this test, we will just ensure metadata isn't expected if IDs were None.
-        base_params["effective_document_ids_for_assertion"] = None
-    else:
-        base_params["effective_document_ids_for_assertion"] = base_params["document_ids"]
-
-    return base_params
-
-
-@pytest.fixture(scope="function")
-def created_index_data(rag_model_instance, index_params_for_function):
-    RAG = rag_model_instance
-    params = index_params_for_function # Renamed for clarity within this fixture
-    index_name = params["index_name"]
-
-    actual_index_path_str = RAG.index(
-        index_name=index_name,
-        documents=params["documents"],
-        document_ids=params["document_ids"], # Pass None if specified in params for auto-generation
-        document_metadatas=params["document_metadatas"],
-        max_document_length=params["max_document_length"],
-        overwrite_index=True # Crucial for test isolation
+@pytest.fixture(scope="session")
+def index_path_fixture_session(persistent_temp_index_root, index_creation_inputs_session):
+    # Construct path as it was originally, assuming experiment_name="colbert"
+    # index_root / experiment_name / "indexes" / index_name
+    index_path = os.path.join(
+        str(persistent_temp_index_root),
+        DEFAULT_EXPERIMENT_NAME, # "colbert"
+        "indexes",
+        index_creation_inputs_session["index_name"],
     )
-    yield {
-        "index_name": index_name,
-        "index_path_str": actual_index_path_str,
-        "params_used": params # Contains effective_document_ids_for_assertion
-    }
-    # Optional: RAG.delete_index(index_name) if it exists, or rely on session cleanup of root.
+    return str(index_path)
 
+@pytest.fixture(scope="session")
+def collection_path_fixture_session(index_path_fixture_session):
+    collection_path = os.path.join(index_path_fixture_session, "collection.json")
+    return str(collection_path)
 
-def get_full_index_path_obj(persistent_test_index_root, index_name):
-    return Path(persistent_test_index_root) / TEST_EXPERIMENT_NAME / "indexes" / index_name
+@pytest.fixture(scope="session")
+def document_metadata_path_fixture_session(index_path_fixture_session):
+    document_metadata_path = os.path.join(index_path_fixture_session, "docid_metadata_map.json")
+    return str(document_metadata_path)
 
+@pytest.fixture(scope="session")
+def pid_docid_map_path_fixture_session(index_path_fixture_session):
+    pid_docid_map_path = os.path.join(index_path_fixture_session, "pid_docid_map.json")
+    return str(pid_docid_map_path)
 
-def test_index_creation_and_structure(created_index_data, persistent_test_index_root):
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-    full_path = get_full_index_path_obj(persistent_test_index_root, index_name)
+# Renamed original fixture to avoid conflict if used directly by tests
+# These are now session-scoped to match the dependent fixtures.
+@pytest.fixture(
+    scope="session",
+    params=[
+        {
+            "collection": collection_samples, # Use original variable name for data
+            "index_name": "no_optional_args",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples, # Use original variable name
+            "index_name": "with_docid",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_metadatas": document_metadatas_samples, # Use original variable name
+            "index_name": "with_metadata",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "index_name": "with_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_docid_metadata",
+            "split_documents": False,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "index_name": "with_docid_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_metadata_split",
+            "split_documents": True,
+        },
+        {
+            "collection": collection_samples,
+            "document_ids": document_ids_samples,
+            "document_metadatas": document_metadatas_samples,
+            "index_name": "with_docid_metadata_split",
+            "split_documents": True,
+        },
+    ],
+    ids=[
+        "No optional arguments",
+        "With document IDs",
+        "With metadata",
+        "With document splitting",
+        "With document IDs and metadata",
+        "With document IDs and splitting",
+        "With metadata and splitting",
+        "With document IDs, metadata, and splitting",
+    ],
+)
+def index_creation_inputs_session(request):
+    # This provides the raw parameters for each test case
+    return request.param
 
-    assert full_path.exists(), f"Index directory {full_path} was not created."
-    assert (full_path / "collection.json").exists(), "collection.json missing."
-    assert (full_path / "pid_docid_map.json").exists(), "pid_docid_map.json missing."
+@pytest.fixture(scope="session")
+def create_index_session(RAG_from_pretrained_model_fixture, index_creation_inputs_session):
+    api_call_params = index_creation_inputs_session.copy()
 
-    if params_used.get("document_metadatas"):
-        assert (full_path / "docid_metadata_map.json").exists(), "docid_metadata_map.json missing when metadata provided."
+    if "collection" in api_call_params:
+        api_call_params["documents"] = api_call_params.pop("collection")
+
+    split_docs = api_call_params.pop("split_documents", False) # Default to False if not present
+    if split_docs:
+        api_call_params["max_document_length"] = 256 # Default for splitting
     else:
-        assert not (full_path / "docid_metadata_map.json").exists(), "docid_metadata_map.json exists when no metadata provided."
+        api_call_params["max_document_length"] = 1_000_000 # Effectively no splitting
 
-    pid_docid_map_data = srsly.read_json(str(full_path / "pid_docid_map.json"))
+    # Ensure 'document_ids' and 'document_metadatas' are present if needed, or pass None
+    api_call_params.setdefault("document_ids", None)
+    api_call_params.setdefault("document_metadatas", None)
+
+    # overwrite_index=True ensures a clean state for each parameterization if run independently
+    # but since this is session scoped and parameterized, this might overwrite for subsequent params.
+    # For strict adherence to "minimal change", we keep the original logic where overwrite
+    # policy is implicitly handled by ColBERT (default "reuse").
+    # If tests need pristine state per param set, they'd need function scope.
+    # Given the original was session-scoped, let's assume sequential execution of params or reuse is fine.
+    api_call_params["overwrite_index"] = True
+
+
+    index_path = RAG_from_pretrained_model_fixture.index(**api_call_params)
+    return index_path
+
+# This fixture ensures that `index_creation_inputs_session` has `document_ids` populated
+# for tests that rely on it later (like metadata checks).
+@pytest.fixture(scope="session", autouse=True)
+def populate_docids_in_inputs_session(
+    create_index_session, # Ensures index is created first
+    index_creation_inputs_session, # The specific parameters for current session iteration
+    pid_docid_map_path_fixture_session, # Path to the pid_docid_map.json for this iteration
+):
+    # If document_ids were not initially provided for this parameter set
+    if "document_ids" not in index_creation_inputs_session or index_creation_inputs_session["document_ids"] is None:
+        # And if metadata was provided (implying IDs are important for mapping)
+        # Or if we just want to ensure IDs are available for later tests like delete
+        pid_docid_map_data = srsly.read_json(pid_docid_map_path_fixture_session)
+        # Extract unique document IDs from the map
+        seen_ids = set()
+        # The PIDs are integers, values are the DocIDs.
+        # RAGPretrainedModel ensures these are strings (UUIDs if auto-generated)
+        effective_doc_ids = [
+            str(x) # Ensure string type consistent with how RAGPretrainedModel handles it
+            for x in list(pid_docid_map_data.values())
+            if not (str(x) in seen_ids or seen_ids.add(str(x))) # Unique doc_ids
+        ]
+        index_creation_inputs_session["document_ids"] = effective_doc_ids
+        # If metadatas were provided but IDs were not, this step is crucial
+        # for aligning them for later assertions.
+        # However, this might be tricky if the number of auto-generated IDs
+        # doesn't match the number of metadatas provided initially.
+        # The original test assumed this alignment; RAGPretrainedModel now requires
+        # document_ids if document_metadatas is provided.
+        # If document_ids was None but document_metadatas was not, an error should occur earlier.
+        # This fixture primarily helps when both were None, or only collection was given.
+
+
+# Tests now use the session-scoped fixtures.
+# Each test function will run ONCE per parameter set defined in `index_creation_inputs_session`.
+# The state of the index will persist across these test functions for a given parameter set.
+
+def test_index_creation(create_index_session): # Uses the created index for the current param set
+    assert os.path.exists(create_index_session), "Index path should exist."
+
+def test_collection_creation(collection_path_fixture_session): # Path for current param set
+    assert os.path.exists(collection_path_fixture_session)
+    collection_data = srsly.read_json(collection_path_fixture_session)
+    assert isinstance(collection_data, list)
+
+def test_pid_docid_map_creation(pid_docid_map_path_fixture_session): # Path for current param set
+    assert os.path.exists(pid_docid_map_path_fixture_session)
+    pid_docid_map_data = srsly.read_json(pid_docid_map_path_fixture_session)
     assert isinstance(pid_docid_map_data, dict)
-    
-    # Check that number of passages (PIDs) is reasonable
-    # If max_document_length is small, expect more passages than original documents
-    if params_used["max_document_length"] < 200 and len(params_used["documents"]) > 0 : # Rough check for splitting
-        assert len(pid_docid_map_data) >= len(params_used["documents"]), "Splitting should result in more or equal passages than documents"
-    elif len(params_used["documents"]) > 0:
-         assert len(pid_docid_map_data) == len(params_used["documents"]), "No splitting should result in equal passages and documents"
+
+def test_document_metadata_creation(
+    index_creation_inputs_session, document_metadata_path_fixture_session
+):
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        assert os.path.exists(document_metadata_path_fixture_session)
+        document_metadata_dict = srsly.read_json(document_metadata_path_fixture_session)
+
+        # Ensure document_ids were populated if metadatas are to be checked
+        assert "document_ids" in index_creation_inputs_session and index_creation_inputs_session["document_ids"] is not None, \
+            "document_ids must be available in inputs to check metadata mapping."
+
+        assert set(document_metadata_dict.keys()) == set(index_creation_inputs_session["document_ids"])
+        for doc_id, metadata in document_metadata_dict.items():
+            idx = index_creation_inputs_session["document_ids"].index(doc_id)
+            assert metadata == index_creation_inputs_session["document_metadatas"][idx]
+    else:
+        assert not os.path.exists(document_metadata_path_fixture_session)
+
+def test_document_metadata_returned_in_search_results(
+    RAG_from_pretrained_model_fixture, index_creation_inputs_session, index_path_fixture_session, persistent_temp_index_root
+):
+    # Use from_index to get a fresh RAG instance for searching this specific index parameterization
+    # This ensures that the RAG instance is configured specifically for the index being tested.
+    # The pretrained_model_name_or_path is crucial for the new API.
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
+
+    results = RAG.search(
+        query="when was miyazaki born", # A generic query
+        index_name=index_creation_inputs_session["index_name"]
+    )
+
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        assert "document_ids" in index_creation_inputs_session and index_creation_inputs_session["document_ids"] is not None, \
+            "document_ids must be available in inputs to check metadata in search results."
+        for result in results:
+            assert "document_metadata" in result
+            doc_id = result["document_id"]
+            # This assumes doc_id from search result will be in the original list
+            # which is true if IDs were provided or correctly inferred.
+            if doc_id in index_creation_inputs_session["document_ids"]:
+                 idx = index_creation_inputs_session["document_ids"].index(doc_id)
+                 expected_metadata = index_creation_inputs_session["document_metadatas"][idx]
+                 assert result["document_metadata"] == expected_metadata
+    else:
+        for result in results:
+            assert "document_metadata" not in result
 
 
-    if params_used.get("effective_document_ids_for_assertion"):
-        provided_doc_ids_set = set(params_used["effective_document_ids_for_assertion"])
-        mapped_doc_ids_set = set(pid_docid_map_data.values())
-        assert provided_doc_ids_set == mapped_doc_ids_set, "Mismatch between provided document_ids and those in pid_docid_map."
+def test_add_to_existing_index(
+    index_creation_inputs_session,
+    index_path_fixture_session, # Path to the specific index for this param set
+    pid_docid_map_path_fixture_session,
+    document_metadata_path_fixture_session,
+    persistent_temp_index_root
+):
+    # Instantiate RAG using from_index to ensure it's targeting the correct index path and root
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
 
+    # This relies on populate_docids_in_inputs_session to have run
+    existing_doc_ids = index_creation_inputs_session.get("document_ids", [])
 
-def test_search_results_and_metadata(rag_model_instance, created_index_data):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-
-    query = "Hayao Miyazaki Ghibli" # A general query likely to hit sample data
-    results = RAG.search(index_name=index_name, query=query, k=1)
-
-    assert isinstance(results, list)
-    if params_used["documents"]:
-        # Results can be empty if k=0 or no match, so check len >= 0
-        assert len(results) <= 1, "Search with k=1 should return at most 1 result."
-        if results:
-            result = results[0]
-            assert "content" in result
-            assert "score" in result
-            assert "rank" in result
-            assert "document_id" in result
-
-            if params_used.get("document_metadatas") and params_used.get("effective_document_ids_for_assertion"):
-                assert "document_metadata" in result, "document_metadata missing in search result."
-                retrieved_doc_id = result["document_id"]
-                try:
-                    original_idx = params_used["effective_document_ids_for_assertion"].index(retrieved_doc_id)
-                    expected_metadata = params_used["document_metadatas"][original_idx]
-                    assert result["document_metadata"] == expected_metadata, "Mismatch in returned document metadata."
-                except ValueError:
-                    # This can happen if the retrieved_doc_id was auto-generated and not in our effective_document_ids_for_assertion
-                    # This part of the check is only fully valid if document_ids were explicitly provided.
-                    if params_used["document_ids"] is not None: # Only fail if we expected to find it
-                        pytest.fail(f"Retrieved document_id {retrieved_doc_id} not in original document_ids for test.")
-            else:
-                assert "document_metadata" not in result, "document_metadata present when it was not indexed."
-    else: # No documents were indexed
-        assert len(results) == 0
-
-
-def test_add_to_existing_index(rag_model_instance, created_index_data, persistent_test_index_root):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    full_index_dir_path = get_full_index_path_obj(persistent_test_index_root, index_name)
-    collection_file_path = full_index_dir_path / "collection.json"
-    pid_docid_map_file_path = full_index_dir_path / "pid_docid_map.json"
-    docid_metadata_map_file_path = full_index_dir_path / "docid_metadata_map.json"
-
-    initial_collection_len = len(srsly.read_json(str(collection_file_path)))
-
-    new_docs_to_add = ["Toei Animation is another famous Japanese animation studio."]
-    new_doc_ids_to_add = ["toei_animation_info_add_test"]
-    new_doc_metadatas_to_add = [{"entity": "organisation", "source": "test_add_to_index"}]
+    new_doc_ids = ["mononoke_added", "sabaku_no_tami_added"]
+    new_docs_to_add = [
+        "Princess Mononoke is an epic film.",
+        "People of the Desert is a manga by Miyazaki.",
+    ]
+    new_doc_metadata_to_add = [
+        {"entity": "film", "source": "test_add"},
+        {"entity": "manga", "source": "test_add"},
+    ]
 
     RAG.add_to_index(
-        index_name=index_name,
-        new_documents=new_docs_to_add,
-        new_document_ids=new_doc_ids_to_add,
-        new_document_metadatas=new_doc_metadatas_to_add,
+        index_name=index_creation_inputs_session["index_name"],
+        new_documents=new_docs_to_add, # API change: new_collection -> new_documents
+        new_document_ids=new_doc_ids,
+        new_document_metadatas=new_doc_metadata_to_add,
     )
 
-    updated_collection = srsly.read_json(str(collection_file_path))
-    assert len(updated_collection) > initial_collection_len
+    pid_docid_map_data_after_add = srsly.read_json(pid_docid_map_path_fixture_session)
+    doc_ids_in_map_after_add = set(list(pid_docid_map_data_after_add.values()))
 
-    updated_pid_docid_map = srsly.read_json(str(pid_docid_map_file_path))
-    assert new_doc_ids_to_add[0] in updated_pid_docid_map.values()
+    # Check for new docs
+    for new_doc_id in new_doc_ids:
+        assert new_doc_id in doc_ids_in_map_after_add
 
-    if docid_metadata_map_file_path.exists() or new_doc_metadatas_to_add: # File may be created if it didn't exist but new metadata is added
-        # Wait for file system to catch up if needed, though srsly should handle it.
-        if not docid_metadata_map_file_path.exists() and new_doc_metadatas_to_add:
-            import time; time.sleep(0.1) # Small delay, usually not needed
+    # Check existing docs are still there
+    for existing_doc_id in existing_doc_ids:
+        assert existing_doc_id in doc_ids_in_map_after_add
 
-        if docid_metadata_map_file_path.exists():
-            updated_docid_metadata_map = srsly.read_json(str(docid_metadata_map_file_path))
-            assert new_doc_ids_to_add[0] in updated_docid_metadata_map
-            assert updated_docid_metadata_map[new_doc_ids_to_add[0]] == new_doc_metadatas_to_add[0]
-    
-    results_for_new = RAG.search(index_name=index_name, query="Toei Animation studio", k=3)
-    found_new_doc_in_search = any(res.get("document_id") == new_doc_ids_to_add[0] for res in results_for_new)
-    assert found_new_doc_in_search, "Newly added document not found in search results."
+    if os.path.exists(document_metadata_path_fixture_session):
+        doc_metadata_dict_after_add = srsly.read_json(document_metadata_path_fixture_session)
+        for new_doc_id in new_doc_ids:
+            assert new_doc_id in doc_metadata_dict_after_add
+        if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+            for existing_doc_id in existing_doc_ids:
+                 assert existing_doc_id in doc_metadata_dict_after_add
+
+def test_delete_from_index(
+    index_creation_inputs_session,
+    index_path_fixture_session, # Path to the specific index
+    pid_docid_map_path_fixture_session,
+    document_metadata_path_fixture_session,
+    persistent_temp_index_root
+):
+    # Instantiate RAG using from_index to ensure it's targeting the correct index path and root
+    RAG = RAGPretrainedModel.from_index(
+        index_path=index_path_fixture_session,
+        pretrained_model_name_or_path=PRETRAINED_MODEL_FOR_TESTS,
+        index_root=str(persistent_temp_index_root),
+        verbose=0
+    )
+
+    # This test assumes 'document_ids' were populated by populate_docids_in_inputs_session
+    # or were part of the original index_creation_inputs_session.
+    if not index_creation_inputs_session.get("document_ids"):
+        pytest.skip("Cannot run delete test if no document_ids are defined for the index.")
+
+    # To ensure this test doesn't interfere with subsequent parameterizations using the same files
+    # if not re-instanced with from_index, we might need function-scoped RAG instances or careful state management.
+    # However, the original structure was session-scoped. We proceed by trying to delete one of the *original* IDs.
+    # This assumes the add_to_index test might have run before.
+
+    doc_ids_before_delete_set = set(srsly.read_json(pid_docid_map_path_fixture_session).values())
+
+    # Pick an ID to delete that was part of the original set for this param, if any
+    # Or, if add_to_index ran, it could be one of those. Let's try to delete one of the "added" ones if present.
+    id_to_delete = "mononoke_added" # From test_add_to_existing_index
+    if id_to_delete not in doc_ids_before_delete_set:
+        # If the "added" ID isn't there (e.g. add test skipped or failed), try an original one
+        if index_creation_inputs_session["document_ids"]:
+            id_to_delete = index_creation_inputs_session["document_ids"][0]
+        else:
+            pytest.skip("No clear ID to delete for this test run.")
 
 
-def test_delete_from_index(rag_model_instance, created_index_data, persistent_test_index_root):
-    RAG = rag_model_instance
-    index_name = created_index_data["index_name"]
-    params_used = created_index_data["params_used"]
-    
-    # This test can only meaningfully run if specific document_ids were used for creation
-    if not params_used.get("effective_document_ids_for_assertion"):
-        pytest.skip("Skipping delete test as no explicit document_ids were used for this index setup.")
+    RAG.delete_from_index(
+        index_name=index_creation_inputs_session["index_name"],
+        document_ids=[id_to_delete], # API change: expects List[str]
+    )
 
-    doc_id_to_delete = params_used["effective_document_ids_for_assertion"][0]
-    content_of_deleted_doc = params_used["documents"][0] # Get content to search for it later
+    pid_docid_map_data_after_delete = srsly.read_json(pid_docid_map_path_fixture_session)
+    doc_ids_in_map_after_delete = set(list(pid_docid_map_data_after_delete.values()))
 
-    full_index_dir_path = get_full_index_path_obj(persistent_test_index_root, index_name)
-    pid_docid_map_file_path = full_index_dir_path / "pid_docid_map.json"
-    docid_metadata_map_file_path = full_index_dir_path / "docid_metadata_map.json"
+    assert id_to_delete not in doc_ids_in_map_after_delete
 
-    RAG.delete_from_index(index_name=index_name, document_ids=[doc_id_to_delete])
-
-    updated_pid_docid_map = srsly.read_json(str(pid_docid_map_file_path))
-    assert doc_id_to_delete not in updated_pid_docid_map.values()
-
-    if params_used.get("document_metadatas"):
-        if docid_metadata_map_file_path.exists(): # File might be deleted if all entries removed
-            updated_docid_metadata_map = srsly.read_json(str(docid_metadata_map_file_path))
-            assert doc_id_to_delete not in updated_docid_metadata_map
-            
-    # Try to search for content of the deleted document
-    results_after_delete = RAG.search(index_name=index_name, query=content_of_deleted_doc, k=5)
-    found_deleted_id_in_results = any(res.get("document_id") == doc_id_to_delete for res in results_after_delete)
-    assert not found_deleted_id_in_results, f"Document ID {doc_id_to_delete} was found in search results after deletion."
+    if "document_metadatas" in index_creation_inputs_session and index_creation_inputs_session["document_metadatas"] is not None:
+        if os.path.exists(document_metadata_path_fixture_session): # Check if metadata file still exists
+            doc_metadata_dict_after_delete = srsly.read_json(document_metadata_path_fixture_session)
+            assert id_to_delete not in doc_metadata_dict_after_delete

--- a/tests/test_pretrained_optional_args.py
+++ b/tests/test_pretrained_optional_args.py
@@ -65,25 +65,23 @@ def pid_docid_map_path_fixture_session(index_path_fixture_session):
     pid_docid_map_path = os.path.join(index_path_fixture_session, "pid_docid_map.json")
     return str(pid_docid_map_path)
 
-# Renamed original fixture to avoid conflict if used directly by tests
-# These are now session-scoped to match the dependent fixtures.
 @pytest.fixture(
     scope="session",
     params=[
         {
-            "collection": collection_samples, # Use original variable name for data
+            "collection": collection_samples,
             "index_name": "no_optional_args",
             "split_documents": False,
         },
         {
             "collection": collection_samples,
-            "document_ids": document_ids_samples, # Use original variable name
+            "document_ids": document_ids_samples,
             "index_name": "with_docid",
             "split_documents": False,
         },
         {
             "collection": collection_samples,
-            "document_metadatas": document_metadatas_samples, # Use original variable name
+            "document_metadatas": document_metadatas_samples,
             "index_name": "with_metadata",
             "split_documents": False,
         },
@@ -145,7 +143,7 @@ def create_index_session(RAG_from_pretrained_model_fixture, index_creation_input
     if split_docs:
         api_call_params["max_document_length"] = 256 # Default for splitting
     else:
-        api_call_params["max_document_length"] = 1_000_000 # Effectively no splitting
+        api_call_params["max_document_length"] = 512 # Cap at model's max sequence length
 
     # Ensure 'document_ids' and 'document_metadatas' are present if needed, or pass None
     api_call_params.setdefault("document_ids", None)
@@ -200,7 +198,7 @@ def populate_docids_in_inputs_session(
 # Each test function will run ONCE per parameter set defined in `index_creation_inputs_session`.
 # The state of the index will persist across these test functions for a given parameter set.
 
-def test_index_creation(create_index_session): # Uses the created index for the current param set
+def test_index_creation(create_index_session):
     assert os.path.exists(create_index_session), "Index path should exist."
 
 def test_collection_creation(collection_path_fixture_session): # Path for current param set

--- a/tests/test_trainer_loading.py
+++ b/tests/test_trainer_loading.py
@@ -11,7 +11,7 @@ def test_finetune(tmp_path):
         pretrained_model_name="colbert-ir/colbertv2.0",
         language_code="en",
     )
-    trainer_config = trainer.model.config
+    trainer_config = trainer.model.base_model_config
 
     assert ColBERTConfig() != trainer_config
     assert trainer_config.query_token == "[Q]"
@@ -33,7 +33,7 @@ def test_raw_model(tmp_path):
         pretrained_model_name="bert-base-uncased",
         language_code="en",
     )
-    trainer_config = trainer.model.config
+    trainer_config = trainer.model.base_model_config
 
     default_config = ColBERTConfig()
 

--- a/tests/test_trainer_loading.py
+++ b/tests/test_trainer_loading.py
@@ -1,9 +1,10 @@
+import pytest
 from colbert.infra import ColBERTConfig
 
 from ragatouille import RAGTrainer
 
 
-def test_finetune():
+def test_finetune(tmp_path):
     """Ensure that the initially loaded config is the one from the pretrained model."""
     trainer = RAGTrainer(
         model_name="test",
@@ -25,7 +26,7 @@ def test_finetune():
     assert trainer_config.name == "kldR2.nway64.ib"
 
 
-def test_raw_model():
+def test_raw_model(tmp_path):
     """Ensure that the default ColBERT configuration is properly loaded when initialising from a BERT-like model"""  # noqa: E501
     trainer = RAGTrainer(
         model_name="test",

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,2116 @@
+version = 1
+revision = 2
+requires-python = ">=3.12.0, <3.13"
+
+[[package]]
+name = "accelerate"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/33/47bbd507e3a851d33d19ce7b2141c5ea3689bfae91ba168044d7db24b0e9/accelerate-1.7.0.tar.gz", hash = "sha256:e8a2a5503d6237b9eee73cc8d36cf543f9c2d8dd2c6713450b322f5e6d53a610", size = 376026, upload-time = "2025-05-15T10:00:52.117Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/bb/be8146c196ad6e4dec78385d91e92591f8a433576c4e04c342a636fcd811/accelerate-1.7.0-py3-none-any.whl", hash = "sha256:cf57165cca28769c6cf2650812371c81b18e05743dfa3c748524b1bb4f2b272f", size = 362095, upload-time = "2025-05-15T10:00:49.914Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.12.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/6e/ab88e7cb2a4058bed2f7870276454f85a7c56cd6da79349eb314fc7bbcaa/aiohttp-3.12.13.tar.gz", hash = "sha256:47e2da578528264a12e4e3dd8dd72a7289e5f812758fe086473fab037a10fcce", size = 7819160, upload-time = "2025-06-14T15:15:41.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/6a/ce40e329788013cd190b1d62bbabb2b6a9673ecb6d836298635b939562ef/aiohttp-3.12.13-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0aa580cf80558557285b49452151b9c69f2fa3ad94c5c9e76e684719a8791b73", size = 700491, upload-time = "2025-06-14T15:14:00.048Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/7150d5cf9163e05081f1c5c64a0cdf3c32d2f56e2ac95db2a28fe90eca69/aiohttp-3.12.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b103a7e414b57e6939cc4dece8e282cfb22043efd0c7298044f6594cf83ab347", size = 475104, upload-time = "2025-06-14T15:14:01.691Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/d42ba4aed039ce6e449b3e2db694328756c152a79804e64e3da5bc19dffc/aiohttp-3.12.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78f64e748e9e741d2eccff9597d09fb3cd962210e5b5716047cbb646dc8fe06f", size = 467948, upload-time = "2025-06-14T15:14:03.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3b/06f0a632775946981d7c4e5a865cddb6e8dfdbaed2f56f9ade7bb4a1039b/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c955989bf4c696d2ededc6b0ccb85a73623ae6e112439398935362bacfaaf6", size = 1714742, upload-time = "2025-06-14T15:14:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a6/2552eebad9ec5e3581a89256276009e6a974dc0793632796af144df8b740/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d640191016763fab76072c87d8854a19e8e65d7a6fcfcbf017926bdbbb30a7e5", size = 1697393, upload-time = "2025-06-14T15:14:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9f/bd08fdde114b3fec7a021381b537b21920cdd2aa29ad48c5dffd8ee314f1/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4dc507481266b410dede95dd9f26c8d6f5a14315372cc48a6e43eac652237d9b", size = 1752486, upload-time = "2025-06-14T15:14:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/affdea8723aec5bd0959171b5490dccd9a91fcc505c8c26c9f1dca73474d/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a94daa873465d518db073bd95d75f14302e0208a08e8c942b2f3f1c07288a75", size = 1798643, upload-time = "2025-06-14T15:14:10.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9d/666d856cc3af3a62ae86393baa3074cc1d591a47d89dc3bf16f6eb2c8d32/aiohttp-3.12.13-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f52420cde4ce0bb9425a375d95577fe082cb5721ecb61da3049b55189e4e6", size = 1718082, upload-time = "2025-06-14T15:14:12.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/3c185293843d17be063dada45efd2712bb6bf6370b37104b4eda908ffdbd/aiohttp-3.12.13-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f7df1f620ec40f1a7fbcb99ea17d7326ea6996715e78f71a1c9a021e31b96b8", size = 1633884, upload-time = "2025-06-14T15:14:14.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/f3413f4b238113be35dfd6794e65029250d4b93caa0974ca572217745bdb/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3062d4ad53b36e17796dce1c0d6da0ad27a015c321e663657ba1cc7659cfc710", size = 1694943, upload-time = "2025-06-14T15:14:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/0e56e8bf12081faca85d14a6929ad5c1263c146149cd66caa7bc12255b6d/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8605e22d2a86b8e51ffb5253d9045ea73683d92d47c0b1438e11a359bdb94462", size = 1716398, upload-time = "2025-06-14T15:14:18.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f3/33192b4761f7f9b2f7f4281365d925d663629cfaea093a64b658b94fc8e1/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:54fbbe6beafc2820de71ece2198458a711e224e116efefa01b7969f3e2b3ddae", size = 1657051, upload-time = "2025-06-14T15:14:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0b/26ddd91ca8f84c48452431cb4c5dd9523b13bc0c9766bda468e072ac9e29/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:050bd277dfc3768b606fd4eae79dd58ceda67d8b0b3c565656a89ae34525d15e", size = 1736611, upload-time = "2025-06-14T15:14:21.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8d/e04569aae853302648e2c138a680a6a2f02e374c5b6711732b29f1e129cc/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2637a60910b58f50f22379b6797466c3aa6ae28a6ab6404e09175ce4955b4e6a", size = 1764586, upload-time = "2025-06-14T15:14:23.979Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/c193c1d1198571d988454e4ed75adc21c55af247a9fda08236602921c8c8/aiohttp-3.12.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e986067357550d1aaa21cfe9897fa19e680110551518a5a7cf44e6c5638cb8b5", size = 1724197, upload-time = "2025-06-14T15:14:25.692Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/07bb8aa11eec762c6b1ff61575eeeb2657df11ab3d3abfa528d95f3e9337/aiohttp-3.12.13-cp312-cp312-win32.whl", hash = "sha256:ac941a80aeea2aaae2875c9500861a3ba356f9ff17b9cb2dbfb5cbf91baaf5bf", size = 421771, upload-time = "2025-06-14T15:14:27.364Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/3ce877e56ec0813069cdc9607cd979575859c597b6fb9b4182c6d5f31886/aiohttp-3.12.13-cp312-cp312-win_amd64.whl", hash = "sha256:671f41e6146a749b6c81cb7fd07f5a8356d46febdaaaf07b0e774ff04830461e", size = 447869, upload-time = "2025-06-14T15:14:29.05Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b5/6d55e80f6d8a08ce22b982eafa278d823b541c925f11ee774b0b9c43473d/aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54", size = 19424, upload-time = "2024-12-13T17:10:40.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5", size = 7597, upload-time = "2024-12-13T17:10:38.469Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "banks"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "griffe" },
+    { name = "jinja2" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/34/2b6697f02ffb68bee50e5fd37d6c64432244d3245603fd62950169dfed7e/banks-2.1.2.tar.gz", hash = "sha256:a0651db9d14b57fa2e115e78f68dbb1b36fe226ad6eef96192542908b1d20c1f", size = 173332, upload-time = "2025-04-20T07:09:21.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4a/7fdca29d1db62f5f5c3446bf8f668beacdb0b5a8aff4247574ddfddc6bcd/banks-2.1.2-py3-none-any.whl", hash = "sha256:7fba451069f6bea376483b8136a0f29cb1e6883133626d00e077e20a3d102c0e", size = 28064, upload-time = "2025-04-20T07:09:20.201Z" },
+]
+
+[[package]]
+name = "batched"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a4/652b2cd4a7bc7828102806fb25e86919e23a29b4a2f72048f98eb7263434/batched-0.1.4.tar.gz", hash = "sha256:98344c450d23b1612d5c2d6462ad43428602c80c12cd8d803ead5e4616dd5c59", size = 23631, upload-time = "2024-12-17T21:06:19.253Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/89/b37005696b8aa5eea1d17ff668f60e33fc4c1457591e2bec196cf2ba07c9/batched-0.1.4-py3-none-any.whl", hash = "sha256:c56addd5fa5ef2f87b5e8d74dd60b278ac70d9615d940656dd83edaeab36287a", size = 28972, upload-time = "2024-12-17T21:06:16.912Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
+name = "bitarray"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/0d/15826c7c2d49a4518a1b24b0d432f1ecad2e0b68168f942058b5de498498/bitarray-3.4.2.tar.gz", hash = "sha256:78ed2b911aabede3a31e3329b1de8abdc8104bd5e0545184ddbd9c7f668f4059", size = 143756, upload-time = "2025-05-21T16:21:44.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/57/0b2b50eb3f50c3144f705d0994171f17fda00ee3a72d563ba764ea235f66/bitarray-3.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a0e498563e0eefa96a1b92461d083de11256f6510b7706d5f2e6473cd9b7137a", size = 141191, upload-time = "2025-05-21T16:18:45.436Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c3/1d9ce4d0041c10ce90d924b8cea63afdda84a64623179045c0c67998922c/bitarray-3.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:114870ab71a0ebdac211aa0a120a54206c333b74b99fdf4b58fbe904979e1fef", size = 138158, upload-time = "2025-05-21T16:18:46.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dd/a8653dac671ba97b1c68ee73b08a0eb2042f24e5e31f51b86afc09588c06/bitarray-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fbf6121978cba4313c31f7cc5961e481242def2b8ddfea34ca27ba9da52c9c1", size = 315834, upload-time = "2025-05-21T16:18:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a2/30547bea0a35f9f953e99f5157749d56304d3f3a96b01a982dd604a9dc48/bitarray-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:423bb4e1bec0bc5d63969e12bcc5cc0081cc5aec4d7b62a6cd8240342aa36107", size = 331317, upload-time = "2025-05-21T16:18:49.169Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b9/1789476280f46455a9a30bcd252fda6fd995583d97d1b919ec0296393e2a/bitarray-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2ef80a96487c82477e8def69a58a218491794f7989b3e191cbaaa7b450315a5c", size = 324416, upload-time = "2025-05-21T16:18:50.917Z" },
+    { url = "https://files.pythonhosted.org/packages/84/89/519c829ca641a3e7b8c9be56d177aaa05572b7e15e4298df4a77959b6a1e/bitarray-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35f5c69a79047e50bc1d54a777541b0a86b213e23559b1ac3d76fa9a42cc5522", size = 317634, upload-time = "2025-05-21T16:18:52.718Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/ebb6a6539261279c0994836b40b99384fa5e27ec239e70b203e310343f80/bitarray-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:002f7b128ed9d18d3ecb51ca78aeea5afffbe8e80d6be4ff2984d045b1c4b937", size = 305392, upload-time = "2025-05-21T16:18:54.888Z" },
+    { url = "https://files.pythonhosted.org/packages/83/04/0ee0d57b2a60fdf881346f196fd92b824f44f4736026da1d8c7970745266/bitarray-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:999bccc72704afcf4a3d9868db4d149c032cdf910f9f7d91e30166978530af7f", size = 309740, upload-time = "2025-05-21T16:18:56.76Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/5ab0339e93097f2a2631ea281a6386c31707011499d5cf68b4e0e37ba124/bitarray-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2e44cfe2bc161cde3b11604f279e3048ef7bd3413837aadbd2ca30b5233c82cb", size = 301607, upload-time = "2025-05-21T16:18:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/bb/b8f697ba6a16c1e393afe75029d069e2dd457e62b112c3cb26768d2e65eb/bitarray-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f408ba3e6f706a0eabae405d1906ceb539f34a318562a91ab9799c5e1712e18c", size = 325942, upload-time = "2025-05-21T16:18:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/77d866a96909c09c5a34f1716f015386f9d9bbbf4b5dc7219f642b8043e2/bitarray-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bf94513ae559b2525e6218e41b03790f866d75df5404490420f2c25e42cf55e7", size = 329491, upload-time = "2025-05-21T16:19:01.205Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6e/633b7d392a39df655c92035da9ee52f7332bb165ae72038692a33a6def6c/bitarray-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f2c88c792815d2755c49a3a1fca256e142c4adfadf1a2142b5a3a37e4d4b871", size = 309566, upload-time = "2025-05-21T16:19:02.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/38/9d7ad6eca72e09b81097176dd66eed3aeaabdea4c24cf6ce25609599ce7b/bitarray-3.4.2-cp312-cp312-win32.whl", hash = "sha256:f4dac6b942c4d7ae5f6eb555ee3993de1432bf9c8f46e3caf74b6671ac5571a3", size = 134600, upload-time = "2025-05-21T16:19:04.057Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/c83ec3d912be73861a064f1a705436f270b8c5b5926350a875bd6c06b6df/bitarray-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:6c37e6814633041307f0df281651a86372b0ccdb1e4768247a87e83e2b68f9b9", size = 141844, upload-time = "2025-05-21T16:19:05.254Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "catalogue"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.6.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936, upload-time = "2025-05-02T08:32:33.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790, upload-time = "2025-05-02T08:32:35.768Z" },
+    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924, upload-time = "2025-05-02T08:32:37.284Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626, upload-time = "2025-05-02T08:32:38.803Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567, upload-time = "2025-05-02T08:32:40.251Z" },
+    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957, upload-time = "2025-05-02T08:32:41.705Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408, upload-time = "2025-05-02T08:32:43.709Z" },
+    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399, upload-time = "2025-05-02T08:32:46.197Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815, upload-time = "2025-05-02T08:32:48.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537, upload-time = "2025-05-02T08:32:49.719Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565, upload-time = "2025-05-02T08:32:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357, upload-time = "2025-05-02T08:32:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776, upload-time = "2025-05-02T08:32:54.573Z" },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
+name = "colbert-ai"
+version = "0.2.20"
+source = { git = "https://github.com/stanford-futuredata/ColBERT.git#8627585ad290c21720eaa54e325e7c8c301d15f6" }
+dependencies = [
+    { name = "bitarray" },
+    { name = "datasets" },
+    { name = "flask" },
+    { name = "gitpython" },
+    { name = "ninja" },
+    { name = "python-dotenv" },
+    { name = "scipy" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "ujson" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
+]
+
+[[package]]
+name = "datasets"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/89/d3d6fef58a488f8569c82fd293ab7cbd4250244d67f425dcae64c63800ea/datasets-3.6.0.tar.gz", hash = "sha256:1b2bf43b19776e2787e181cfd329cb0ca1a358ea014780c3581e0f276375e041", size = 569336, upload-time = "2025-05-07T15:15:02.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/34/a08b0ee99715eaba118cbe19a71f7b5e2425c2718ef96007c325944a1152/datasets-3.6.0-py3-none-any.whl", hash = "sha256:25000c4a2c0873a710df127d08a202a06eab7bf42441a6bc278b499c2f72cd1b", size = 491546, upload-time = "2025-05-07T15:14:59.742Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload-time = "2024-01-27T23:42:16.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload-time = "2024-01-27T23:42:14.239Z" },
+]
+
+[[package]]
+name = "dirtyjson"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782, upload-time = "2022-11-28T23:32:33.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197, upload-time = "2022-11-28T23:32:31.219Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/9a/e33fc563f007924dd4ec3c5101fe5320298d6c13c158a24a9ed849058569/faiss_cpu-1.11.0.tar.gz", hash = "sha256:44877b896a2b30a61e35ea4970d008e8822545cb340eca4eff223ac7f40a1db9", size = 70218, upload-time = "2025-04-28T07:48:30.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/d3/7178fa07047fd770964a83543329bb5e3fc1447004cfd85186ccf65ec3ee/faiss_cpu-1.11.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:356437b9a46f98c25831cdae70ca484bd6c05065af6256d87f6505005e9135b9", size = 3313807, upload-time = "2025-04-28T07:47:54.533Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/71/25f5f7b70a9f22a3efe19e7288278da460b043a3b60ad98e4e47401ed5aa/faiss_cpu-1.11.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c4a3d35993e614847f3221c6931529c0bac637a00eff0d55293e1db5cb98c85f", size = 7913537, upload-time = "2025-04-28T07:47:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c8/a5cb8466c981ad47750e1d5fda3d4223c82f9da947538749a582b3a2d35c/faiss_cpu-1.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8f9af33e0b8324e8199b93eb70ac4a951df02802a9dcff88e9afc183b11666f0", size = 3785180, upload-time = "2025-04-28T07:47:59.004Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eaf15a7d80e1aad74f56cf737b31b4547a1a664ad3c6e4cfaf90e82454a8/faiss_cpu-1.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:48b7e7876829e6bdf7333041800fa3c1753bb0c47e07662e3ef55aca86981430", size = 31287630, upload-time = "2025-04-28T07:48:01.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5c/902a78347e9c47baaf133e47863134e564c39f9afe105795b16ee986b0df/faiss_cpu-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:bdc199311266d2be9d299da52361cad981393327b2b8aa55af31a1b75eaaf522", size = 15005398, upload-time = "2025-04-28T07:48:04.232Z" },
+]
+
+[[package]]
+name = "fast-pytorch-kmeans"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/14/50184ebdbecf31fe525d60fe2e77a86476e8b3f36b6398c99b0447914525/fast_pytorch_kmeans-0.2.2.tar.gz", hash = "sha256:d796fd786efd8dcd1684815d395b740d3bdf32c4221626c8a26786ff3b9f7cbe", size = 7948, upload-time = "2024-12-05T02:59:23.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/cf/f082ad98d4d143b59bdc02027673cfd76280dd23dcd71218c156a4dbc627/fast_pytorch_kmeans-0.2.2-py3-none-any.whl", hash = "sha256:dd79f5123893ab905af9eeda3eb387e5f91811591c6c3963d3536544d07d43ac", size = 9750, upload-time = "2024-12-05T02:59:22.391Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.115.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/55/ae499352d82338331ca1e28c7f4a63bfd09479b16395dce38cf50a39e2c2/fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681", size = 295236, upload-time = "2025-03-23T22:55:43.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/b3/b51f09c2ba432a576fe63758bddc81f78f0c6309d9e5c10d194313bf021e/fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d", size = 95164, upload-time = "2025-03-23T22:55:42.101Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/de/e47735752347f4128bcf354e0da07ef311a78244eba9e3dc1d4a5ab21a98/flask-3.1.1.tar.gz", hash = "sha256:284c7b8f2f58cb737f0cf1c30fd7eaf0ccfcde196099d24ecede3fc2005aa59e", size = 753440, upload-time = "2025-05-13T15:01:17.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/68/9d4508e893976286d2ead7f8f571314af6c2037af34853a30fd769c02e9d/flask-3.1.1-py3-none-any.whl", hash = "sha256:07aae2bb5eaf77993ef57e357491839f5fd9f4dc281593a81a9e4d79a24f295c", size = 103305, upload-time = "2025-05-13T15:01:15.591Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b1/b64018016eeb087db503b038296fd782586432b9c077fc5c7839e9cb6ef6/frozenlist-1.7.0.tar.gz", hash = "sha256:2e310d81923c2437ea8670467121cc3e9b0f76d3043cc1d2331d56c7fb7a3a8f", size = 45078, upload-time = "2025-06-09T23:02:35.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a2/c8131383f1e66adad5f6ecfcce383d584ca94055a34d683bbb24ac5f2f1c/frozenlist-1.7.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3dbf9952c4bb0e90e98aec1bd992b3318685005702656bc6f67c1a32b76787f2", size = 81424, upload-time = "2025-06-09T23:00:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/9d/02754159955088cb52567337d1113f945b9e444c4960771ea90eb73de8db/frozenlist-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1f5906d3359300b8a9bb194239491122e6cf1444c2efb88865426f170c262cdb", size = 47952, upload-time = "2025-06-09T23:00:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7a/0046ef1bd6699b40acd2067ed6d6670b4db2f425c56980fa21c982c2a9db/frozenlist-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3dabd5a8f84573c8d10d8859a50ea2dec01eea372031929871368c09fa103478", size = 46688, upload-time = "2025-06-09T23:00:44.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a2/a910bafe29c86997363fb4c02069df4ff0b5bc39d33c5198b4e9dd42d8f8/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa57daa5917f1738064f302bf2626281a1cb01920c32f711fbc7bc36111058a8", size = 243084, upload-time = "2025-06-09T23:00:46.125Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3e/5036af9d5031374c64c387469bfcc3af537fc0f5b1187d83a1cf6fab1639/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c193dda2b6d49f4c4398962810fa7d7c78f032bf45572b3e04dd5249dff27e08", size = 233524, upload-time = "2025-06-09T23:00:47.73Z" },
+    { url = "https://files.pythonhosted.org/packages/06/39/6a17b7c107a2887e781a48ecf20ad20f1c39d94b2a548c83615b5b879f28/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfe2b675cf0aaa6d61bf8fbffd3c274b3c9b7b1623beb3809df8a81399a4a9c4", size = 248493, upload-time = "2025-06-09T23:00:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/711d1337c7327d88c44d91dd0f556a1c47fb99afc060ae0ef66b4d24793d/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8fc5d5cda37f62b262405cf9652cf0856839c4be8ee41be0afe8858f17f4c94b", size = 244116, upload-time = "2025-06-09T23:00:51.352Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fe/74e6ec0639c115df13d5850e75722750adabdc7de24e37e05a40527ca539/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0d5ce521d1dd7d620198829b87ea002956e4319002ef0bc8d3e6d045cb4646e", size = 224557, upload-time = "2025-06-09T23:00:52.855Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/48421f62a6f77c553575201e89048e97198046b793f4a089c79a6e3268bd/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:488d0a7d6a0008ca0db273c542098a0fa9e7dfaa7e57f70acef43f32b3f69dca", size = 241820, upload-time = "2025-06-09T23:00:54.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fa/cb4a76bea23047c8462976ea7b7a2bf53997a0ca171302deae9d6dd12096/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:15a7eaba63983d22c54d255b854e8108e7e5f3e89f647fc854bd77a237e767df", size = 236542, upload-time = "2025-06-09T23:00:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/476a4b5cfaa0ec94d3f808f193301debff2ea42288a099afe60757ef6282/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1eaa7e9c6d15df825bf255649e05bd8a74b04a4d2baa1ae46d9c2d00b2ca2cb5", size = 249350, upload-time = "2025-06-09T23:00:58.468Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ba/9a28042f84a6bf8ea5dbc81cfff8eaef18d78b2a1ad9d51c7bc5b029ad16/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4389e06714cfa9d47ab87f784a7c5be91d3934cd6e9a7b85beef808297cc025", size = 225093, upload-time = "2025-06-09T23:01:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/29/3a32959e68f9cf000b04e79ba574527c17e8842e38c91d68214a37455786/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:73bd45e1488c40b63fe5a7df892baf9e2a4d4bb6409a2b3b78ac1c6236178e01", size = 245482, upload-time = "2025-06-09T23:01:01.474Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e8/edf2f9e00da553f07f5fa165325cfc302dead715cab6ac8336a5f3d0adc2/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99886d98e1643269760e5fe0df31e5ae7050788dd288947f7f007209b8c33f08", size = 249590, upload-time = "2025-06-09T23:01:02.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/80/9a0eb48b944050f94cc51ee1c413eb14a39543cc4f760ed12657a5a3c45a/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:290a172aae5a4c278c6da8a96222e6337744cd9c77313efe33d5670b9f65fc43", size = 237785, upload-time = "2025-06-09T23:01:05.095Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/74/87601e0fb0369b7a2baf404ea921769c53b7ae00dee7dcfe5162c8c6dbf0/frozenlist-1.7.0-cp312-cp312-win32.whl", hash = "sha256:426c7bc70e07cfebc178bc4c2bf2d861d720c4fff172181eeb4a4c41d4ca2ad3", size = 39487, upload-time = "2025-06-09T23:01:06.54Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/c026e9a9fc17585a9d461f65d8593d281fedf55fbf7eb53f16c6df2392f9/frozenlist-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:563b72efe5da92e02eb68c59cb37205457c977aa7a449ed1b37e6939e5c47c6a", size = 43874, upload-time = "2025-06-09T23:01:07.752Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/45/b82e3c16be2182bff01179db177fe144d58b5dc787a7d4492c6ed8b9317f/frozenlist-1.7.0-py3-none-any.whl", hash = "sha256:9a5af342e34f7e97caf8c995864c7a396418ae2859cc6fdf1b1073020d516a7e", size = 13106, upload-time = "2025-06-09T23:02:34.204Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2025.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/f4/5721faf47b8c499e776bc34c6a8fc17efdf7fdef0b00f398128bc5dcb4ac/fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972", size = 298491, upload-time = "2025-03-07T21:47:56.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/53/eb690efa8513166adef3e0669afd31e95ffde69fb3c52ec2ac7223ed6018/fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3", size = 193615, upload-time = "2025-03-07T21:47:54.809Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196, upload-time = "2025-01-02T07:32:43.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599, upload-time = "2025-01-02T07:32:40.731Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/92/bb85bd6e80148a4d2e0c59f7c0c2891029f8fd510183afc7d8d2feeed9b6/greenlet-3.2.3.tar.gz", hash = "sha256:8b0dd8ae4c0d6f5e54ee55ba935eeb3d735a9b58a8a1e5b5cbab64e01a39f365", size = 185752, upload-time = "2025-06-05T16:16:09.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
+    { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/3e/5aa9a61f7c3c47b0b52a1d930302992229d191bf4bc76447b324b731510a/griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b", size = 395137, upload-time = "2025-04-23T11:29:09.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/c6/5c20af38c2a57c15d87f7f38bee77d63c1d2a3689f74fefaf35915dd12b2/griffe-1.7.3-py3-none-any.whl", hash = "sha256:c6b3ee30c2f0f17f30bcdef5068d6ab7a2a4f1b8bf1a3e74b56fffd21e1c5f75", size = 129303, upload-time = "2025-04-23T11:29:07.145Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/dc/dc091aeeb671e71cbec30e84963f9c0202c17337b24b0a800e7d205543e8/hf_xet-1.1.3.tar.gz", hash = "sha256:a5f09b1dd24e6ff6bcedb4b0ddab2d81824098bb002cf8b4ffa780545fa348c3", size = 488127, upload-time = "2025-06-04T00:47:27.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/1f/bc01a4c0894973adebbcd4aa338a06815c76333ebb3921d94dcbd40dae6a/hf_xet-1.1.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c3b508b5f583a75641aebf732853deb058953370ce8184f5dabc49f803b0819b", size = 2256929, upload-time = "2025-06-04T00:47:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/78/07/6ef50851b5c6b45b77a6e018fa299c69a2db3b8bbd0d5af594c0238b1ceb/hf_xet-1.1.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b788a61977fbe6b5186e66239e2a329a3f0b7e7ff50dad38984c0c74f44aeca1", size = 2153719, upload-time = "2025-06-04T00:47:19.302Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/e929e6e3db6e4758c2adf0f2ca2c59287f1b76229d8bdc1a4c9cfc05212e/hf_xet-1.1.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd2da210856444a34aad8ada2fc12f70dabed7cc20f37e90754d1d9b43bc0534", size = 4820519, upload-time = "2025-06-04T00:47:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2e/03f89c5014a5aafaa9b150655f811798a317036646623bdaace25f485ae8/hf_xet-1.1.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8203f52827e3df65981984936654a5b390566336956f65765a8aa58c362bb841", size = 4964121, upload-time = "2025-06-04T00:47:15.17Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8b/5cd399a92b47d98086f55fc72d69bc9ea5e5c6f27a9ed3e0cdd6be4e58a3/hf_xet-1.1.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:30c575a5306f8e6fda37edb866762140a435037365eba7a17ce7bd0bc0216a8b", size = 5283017, upload-time = "2025-06-04T00:47:23.239Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e3/2fcec58d2fcfd25ff07feb876f466cfa11f8dcf9d3b742c07fe9dd51ee0a/hf_xet-1.1.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7c1a6aa6abed1f696f8099aa9796ca04c9ee778a58728a115607de9cc4638ff1", size = 4970349, upload-time = "2025-06-04T00:47:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/53/bf/10ca917e335861101017ff46044c90e517b574fbb37219347b83be1952f6/hf_xet-1.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:b578ae5ac9c056296bb0df9d018e597c8dc6390c5266f35b5c44696003cde9f3", size = 2310934, upload-time = "2025-06-04T00:47:29.632Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/8a/1362d565fefabaa4185cf3ae842a98dbc5b35146f5694f7080f043a6952f/huggingface_hub-0.33.0.tar.gz", hash = "sha256:aa31f70d29439d00ff7a33837c03f1f9dd83971ce4e29ad664d63ffb17d3bb97", size = 426179, upload-time = "2025-06-11T17:08:07.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/fb/53587a89fbc00799e4179796f51b3ad713c5de6bb680b2becb6d37c94649/huggingface_hub-0.33.0-py3-none-any.whl", hash = "sha256:e8668875b40c68f9929150d99727d39e5ebb8a05a98e4191b908dc7ded9074b3", size = 514799, upload-time = "2025-06-11T17:08:05.757Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/9d/ae7ddb4b8ab3fb1b51faf4deb36cb48a4fbbd7cb36bad6a5fca4741306f7/jiter-0.10.0.tar.gz", hash = "sha256:07a7142c38aacc85194391108dc91b5b57093c978a9932bd86a36862759d9500", size = 162759, upload-time = "2025-05-18T19:04:59.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b5/348b3313c58f5fbfb2194eb4d07e46a35748ba6e5b3b3046143f3040bafa/jiter-0.10.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1e274728e4a5345a6dde2d343c8da018b9d4bd4350f5a472fa91f66fda44911b", size = 312262, upload-time = "2025-05-18T19:03:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/4a/6a2397096162b21645162825f058d1709a02965606e537e3304b02742e9b/jiter-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7202ae396446c988cb2a5feb33a543ab2165b786ac97f53b59aafb803fef0744", size = 320124, upload-time = "2025-05-18T19:03:46.341Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/1ce02cade7516b726dd88f59a4ee46914bf79d1676d1228ef2002ed2f1c9/jiter-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23ba7722d6748b6920ed02a8f1726fb4b33e0fd2f3f621816a8b486c66410ab2", size = 345330, upload-time = "2025-05-18T19:03:47.596Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d0/bb6b4f209a77190ce10ea8d7e50bf3725fc16d3372d0a9f11985a2b23eff/jiter-0.10.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:371eab43c0a288537d30e1f0b193bc4eca90439fc08a022dd83e5e07500ed026", size = 369670, upload-time = "2025-05-18T19:03:49.334Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f5/a61787da9b8847a601e6827fbc42ecb12be2c925ced3252c8ffcb56afcaf/jiter-0.10.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c675736059020365cebc845a820214765162728b51ab1e03a1b7b3abb70f74c", size = 489057, upload-time = "2025-05-18T19:03:50.66Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e4/6f906272810a7b21406c760a53aadbe52e99ee070fc5c0cb191e316de30b/jiter-0.10.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c5867d40ab716e4684858e4887489685968a47e3ba222e44cde6e4a2154f959", size = 389372, upload-time = "2025-05-18T19:03:51.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ba/77013b0b8ba904bf3762f11e0129b8928bff7f978a81838dfcc958ad5728/jiter-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395bb9a26111b60141757d874d27fdea01b17e8fac958b91c20128ba8f4acc8a", size = 352038, upload-time = "2025-05-18T19:03:53.703Z" },
+    { url = "https://files.pythonhosted.org/packages/67/27/c62568e3ccb03368dbcc44a1ef3a423cb86778a4389e995125d3d1aaa0a4/jiter-0.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6842184aed5cdb07e0c7e20e5bdcfafe33515ee1741a6835353bb45fe5d1bd95", size = 391538, upload-time = "2025-05-18T19:03:55.046Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/72/0d6b7e31fc17a8fdce76164884edef0698ba556b8eb0af9546ae1a06b91d/jiter-0.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:62755d1bcea9876770d4df713d82606c8c1a3dca88ff39046b85a048566d56ea", size = 523557, upload-time = "2025-05-18T19:03:56.386Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/09/bc1661fbbcbeb6244bd2904ff3a06f340aa77a2b94e5a7373fd165960ea3/jiter-0.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:533efbce2cacec78d5ba73a41756beff8431dfa1694b6346ce7af3a12c42202b", size = 514202, upload-time = "2025-05-18T19:03:57.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/84/5a5d5400e9d4d54b8004c9673bbe4403928a00d28529ff35b19e9d176b19/jiter-0.10.0-cp312-cp312-win32.whl", hash = "sha256:8be921f0cadd245e981b964dfbcd6fd4bc4e254cdc069490416dd7a2632ecc01", size = 211781, upload-time = "2025-05-18T19:03:59.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/7ec47455e26f2d6e5f2ea4951a0652c06e5b995c291f723973ae9e724a65/jiter-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:a7c7d785ae9dda68c2678532a5a1581347e9c15362ae9f6e68f3fdbfb64f2e49", size = 206176, upload-time = "2025-05-18T19:04:00.305Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475, upload-time = "2025-05-23T12:04:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746, upload-time = "2025-05-23T12:04:35.124Z" },
+]
+
+[[package]]
+name = "llama-cloud"
+version = "0.1.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/02/c6428db51ec5dfcadc9a29e16fcb3829a10d82f6deebf71db0412fc80ef0/llama_cloud-0.1.26.tar.gz", hash = "sha256:b307f91b1ad97189b5278119ac4ad665931b65f240fb643b3e384d0a1fc81f56", size = 92788, upload-time = "2025-06-10T23:35:09.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/2a/80864124d649ef06a3cbc93adb0b236dcc3d95348a36e65b852e3ccc9bb4/llama_cloud-0.1.26-py3-none-any.whl", hash = "sha256:2c0b2663e619b71c0645885ef622d6443725ab37bdc6ae5fb723e097f3af9459", size = 266775, upload-time = "2025-06-10T23:35:08.205Z" },
+]
+
+[[package]]
+name = "llama-cloud-services"
+version = "0.6.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "llama-cloud" },
+    { name = "llama-index-core" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/85/84802a4173c79f804a8f17338d4210a882a9ba2e8861995ab2fac8ad842d/llama_cloud_services-0.6.33.tar.gz", hash = "sha256:ed043cfb37945cca3aa20858c25f3f7c5e2285a72b5d1264eedb3f6a7d5d90b0", size = 34452, upload-time = "2025-06-16T08:34:38.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/a7/faa71cda12dfb4ccd044e1e5d42a2cba7b190d7d4430a509369430756236/llama_cloud_services-0.6.33-py3-none-any.whl", hash = "sha256:47120f31051feba8919f06cf5f94b69994baccba8a09afb4aaa73701bee66452", size = 39771, upload-time = "2025-06-16T08:34:37.405Z" },
+]
+
+[[package]]
+name = "llama-index"
+version = "0.12.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-agent-openai" },
+    { name = "llama-index-cli" },
+    { name = "llama-index-core" },
+    { name = "llama-index-embeddings-openai" },
+    { name = "llama-index-indices-managed-llama-cloud" },
+    { name = "llama-index-llms-openai" },
+    { name = "llama-index-multi-modal-llms-openai" },
+    { name = "llama-index-program-openai" },
+    { name = "llama-index-question-gen-openai" },
+    { name = "llama-index-readers-file" },
+    { name = "llama-index-readers-llama-parse" },
+    { name = "nltk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/86/7e36d3f7b0606cba5e4862bb62f8e6bef91b7c45229f15262faf2c92f6e3/llama_index-0.12.42.tar.gz", hash = "sha256:d2bd2b9ea06bc42ebe74697aaa0b66c79bd3dee8ff5d06c53294d49ca44512e7", size = 8073, upload-time = "2025-06-12T04:59:38.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/9a/3044c50dd7cd7340763ed25e5ee7ee59917281735725eb73f62fe110333e/llama_index-0.12.42-py3-none-any.whl", hash = "sha256:9a304b2bd71d6772fc6c2e9995e119815c00716fc98813b15ea79caee09f1fe2", size = 7085, upload-time = "2025-06-12T04:59:37.071Z" },
+]
+
+[[package]]
+name = "llama-index-agent-openai"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-llms-openai" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/0a/aae8356485e4e4c5998ff769ec4f483f6a3148be36ba689e3a6bcf4f1474/llama_index_agent_openai-0.4.11.tar.gz", hash = "sha256:bcd25f34412d1700f19a691c5f47db48f438f72a09f7467a20cffc6d3fdc326c", size = 12241, upload-time = "2025-06-11T23:21:44.356Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/22/fc5ecdc530ce317e6a8eac4a03aa0d37303be50712c2ef2796cad2388f48/llama_index_agent_openai-0.4.11-py3-none-any.whl", hash = "sha256:957bae65a072bde8b6c4c49fbd6e1cb47c182f55fa8fd2d748eb008176c22fe0", size = 14224, upload-time = "2025-06-11T23:21:43.218Z" },
+]
+
+[[package]]
+name = "llama-index-cli"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-embeddings-openai" },
+    { name = "llama-index-llms-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/a3/1acdb3aa3f4a90a1d5275dcaa4acea295aa3d9102d7529c56734c0cde46c/llama_index_cli-0.4.3.tar.gz", hash = "sha256:dae8183a10551bbd89686b94ed294a6cf44633c3dd6285c4f991c85031b7a55f", size = 25274, upload-time = "2025-06-04T21:06:16.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e5/0e7f9515c88cf4e791bf243f83246e2634c01ec5cdbd7245307b28b48487/llama_index_cli-0.4.3-py3-none-any.whl", hash = "sha256:f0af55ce4b90e5a2466e394b88f4ac6085ea3e6286019bc3f49de6673ce2238d", size = 28564, upload-time = "2025-06-04T21:06:09.304Z" },
+]
+
+[[package]]
+name = "llama-index-core"
+version = "0.12.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "banks" },
+    { name = "dataclasses-json" },
+    { name = "deprecated" },
+    { name = "dirtyjson" },
+    { name = "filetype" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "nest-asyncio" },
+    { name = "networkx" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/67/ef1fc8c3b0676b524fd6b67a0e3e082996d768d227ed2b4b39f78119253b/llama_index_core-0.12.42.tar.gz", hash = "sha256:cff21fe15610826997c876a6b1d28d52727932c5f9c2af04b23e041a10f40a24", size = 7292833, upload-time = "2025-06-12T03:07:06.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/92/dc47b702da141d0f617ee86d26b5bdb62ed9a52518d1a5f271e91337e4a7/llama_index_core-0.12.42-py3-none-any.whl", hash = "sha256:0534cd9a4f6113175aa406a47ae9a683b5a43fd55532e9dbbffa96838ff18e07", size = 7665930, upload-time = "2025-06-12T03:06:58.387Z" },
+]
+
+[[package]]
+name = "llama-index-embeddings-openai"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/02/a2604ef3a167131fdd701888f45f16c8efa6d523d02efe8c4e640238f4ea/llama_index_embeddings_openai-0.3.1.tar.gz", hash = "sha256:1368aad3ce24cbaed23d5ad251343cef1eb7b4a06d6563d6606d59cb347fef20", size = 5492, upload-time = "2024-11-27T16:04:17.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/45/ca55b91c4ac1b6251d4099fa44121a6c012129822906cadcc27b8cfb33a4/llama_index_embeddings_openai-0.3.1-py3-none-any.whl", hash = "sha256:f15a3d13da9b6b21b8bd51d337197879a453d1605e625a1c6d45e741756c0290", size = 6177, upload-time = "2024-11-27T16:04:15.981Z" },
+]
+
+[[package]]
+name = "llama-index-indices-managed-llama-cloud"
+version = "0.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-cloud" },
+    { name = "llama-index-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/1b/886a67f488de729195c7a25a12ed655cda9d35bf6196e9d147978e27e965/llama_index_indices_managed_llama_cloud-0.7.7.tar.gz", hash = "sha256:7fd730a2967dc20eb422ae2fa4028b4cf7023114a5cfadb5232355137754186f", size = 14774, upload-time = "2025-06-11T22:48:00.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/38/9910dd096a6f014a9cb54dab5dcf4a92775f22497d38b12f0fc6913d2d0a/llama_index_indices_managed_llama_cloud-0.7.7-py3-none-any.whl", hash = "sha256:5a8a24de6a2f425a5616818582b57f603e4192179443045f636e865efc6692c4", size = 16469, upload-time = "2025-06-11T22:47:59.743Z" },
+]
+
+[[package]]
+name = "llama-index-llms-openai"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/39/a7ce514fb500951e9edb713ed918a9ffe49f1a76fccfc531a4ec5c7fe15a/llama_index_llms_openai-0.4.7.tar.gz", hash = "sha256:564af8ab39fb3f3adfeae73a59c0dca46c099ab844a28e725eee0c551d4869f8", size = 24251, upload-time = "2025-06-16T03:38:47.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/e9/391926dad180ced6bb37a62edddb8483fbecde411239bd5e726841bb77b4/llama_index_llms_openai-0.4.7-py3-none-any.whl", hash = "sha256:3b8d9d3c1bcadc2cff09724de70f074f43eafd5b7048a91247c9a41b7cd6216d", size = 25365, upload-time = "2025-06-16T03:38:45.72Z" },
+]
+
+[[package]]
+name = "llama-index-multi-modal-llms-openai"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-llms-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/77/0ece3c7887e9c7242fc7cc2a184374bbeb08a35783d71a8466e1dd18ccfc/llama_index_multi_modal_llms_openai-0.5.1.tar.gz", hash = "sha256:df3aff00c36023c5f8c49f972a325f71823ed0f4dd9cd479955d76afc146575f", size = 3708, upload-time = "2025-05-30T23:08:09.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a5/6181a385af1caef88e1d0d3919c399ba7e031190fc0be4fd5242875c5b0e/llama_index_multi_modal_llms_openai-0.5.1-py3-none-any.whl", hash = "sha256:69bb9c310c323ce51038f0d40719f546d0d4e0853835a4f5cfa21f07dbb0b91e", size = 3362, upload-time = "2025-05-30T23:08:08.977Z" },
+]
+
+[[package]]
+name = "llama-index-program-openai"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-agent-openai" },
+    { name = "llama-index-core" },
+    { name = "llama-index-llms-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/81/9caa34e80adce1adb715ae083a54ad45c8fc0d9aef0f2d80d61c1b805ab6/llama_index_program_openai-0.3.2.tar.gz", hash = "sha256:04c959a2e616489894bd2eeebb99500d6f1c17d588c3da0ddc75ebd3eb7451ee", size = 6301, upload-time = "2025-05-30T23:00:27.872Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/80/d6ac8afafdd38115d61214891c36876e64f429809abff873660fe30862fe/llama_index_program_openai-0.3.2-py3-none-any.whl", hash = "sha256:451829ae53e074e7b47dcc60a9dd155fcf9d1dcbc1754074bdadd6aab4ceb9aa", size = 6129, upload-time = "2025-05-30T23:00:26.64Z" },
+]
+
+[[package]]
+name = "llama-index-question-gen-openai"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-llms-openai" },
+    { name = "llama-index-program-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6e/19c5051c81ef5fca597d13c6d41b863535521565b1414ab5ab0e5e8c1297/llama_index_question_gen_openai-0.3.1.tar.gz", hash = "sha256:5e9311b433cc2581ff8a531fa19fb3aa21815baff75aaacdef11760ac9522aa9", size = 4107, upload-time = "2025-05-30T23:00:31.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/2a/652593d0bd24f901776db0d1778a42363ea2656530da18215f413ce4f981/llama_index_question_gen_openai-0.3.1-py3-none-any.whl", hash = "sha256:1ce266f6c8373fc8d884ff83a44dfbacecde2301785db7144872db51b8b99429", size = 3733, upload-time = "2025-05-30T23:00:29.965Z" },
+]
+
+[[package]]
+name = "llama-index-readers-file"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "llama-index-core" },
+    { name = "pandas" },
+    { name = "pypdf" },
+    { name = "striprtf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/aa/517a79b9fa57ff42dc3d0ae801676b794c81bbceacc2350c948ebe9cfa7e/llama_index_readers_file-0.4.9.tar.gz", hash = "sha256:b705fd42a2875af03d343c66b28138471800cd13a67efcc48ae2983b39d816c7", size = 22710, upload-time = "2025-06-05T04:26:00.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/65/ebc692d80f55501771eec0854cea90c9f7ecdbd688a74e89357ef8afa285/llama_index_readers_file-0.4.9-py3-none-any.whl", hash = "sha256:71f1d0d2ea22012bf233ed4afb9b9b6b2f098d26286e38ed82e3c4af685e07bd", size = 40976, upload-time = "2025-06-05T04:25:59.397Z" },
+]
+
+[[package]]
+name = "llama-index-readers-llama-parse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-parse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/30/4611821286f82ba7b5842295607baa876262db86f88b87d83595eed172bf/llama_index_readers_llama_parse-0.4.0.tar.gz", hash = "sha256:e99ec56f4f8546d7fda1a7c1ae26162fb9acb7ebcac343b5abdb4234b4644e0f", size = 2472, upload-time = "2024-11-18T00:00:08.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/4f/e30d4257fe9e4224f5612b77fe99aaceddae411b2e74ca30534491de3e6f/llama_index_readers_llama_parse-0.4.0-py3-none-any.whl", hash = "sha256:574e48386f28d2c86c3f961ca4a4906910312f3400dd0c53014465bfbc6b32bf", size = 2472, upload-time = "2024-11-18T00:00:07.293Z" },
+]
+
+[[package]]
+name = "llama-parse"
+version = "0.6.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-cloud-services" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/87/9c827dac7095f7a7d13b89399d32fab37d84a2f9d148ff71d8dd857ffd21/llama_parse-0.6.33.tar.gz", hash = "sha256:43d37fd45386596cddf6a4246af9de34d72e637e18dd8d58b5cc595cf409c964", size = 3539, upload-time = "2025-06-16T08:36:09.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/2c/373035cc17509bc51fb6eb156eccc153221838ba0806516306d5ba6affad/llama_parse-0.6.33-py3-none-any.whl", hash = "sha256:2d9188039d4ae899099a1cd161e9bbe0bac4dc4d9ddbaf19bb9b5db6af19948f", size = 4945, upload-time = "2025-06-16T08:36:08.207Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+]
+
+[[package]]
+name = "marshmallow"
+version = "3.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825, upload-time = "2025-02-03T15:32:25.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878, upload-time = "2025-02-03T15:32:22.295Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/2f/a3470242707058fe856fe59241eee5635d79087100b7042a867368863a27/multidict-6.4.4.tar.gz", hash = "sha256:69ee9e6ba214b5245031b76233dd95408a0fd57fdb019ddcc1ead4790932a8e8", size = 90183, upload-time = "2025-05-19T14:16:37.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/b5/5675377da23d60875fe7dae6be841787755878e315e2f517235f22f59e18/multidict-6.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dc388f75a1c00000824bf28b7633e40854f4127ede80512b44c3cfeeea1839a2", size = 64293, upload-time = "2025-05-19T14:14:44.724Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a7/be384a482754bb8c95d2bbe91717bf7ccce6dc38c18569997a11f95aa554/multidict-6.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:98af87593a666f739d9dba5d0ae86e01b0e1a9cfcd2e30d2d361fbbbd1a9162d", size = 38096, upload-time = "2025-05-19T14:14:45.95Z" },
+    { url = "https://files.pythonhosted.org/packages/66/6d/d59854bb4352306145bdfd1704d210731c1bb2c890bfee31fb7bbc1c4c7f/multidict-6.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aff4cafea2d120327d55eadd6b7f1136a8e5a0ecf6fb3b6863e8aca32cd8e50a", size = 37214, upload-time = "2025-05-19T14:14:47.158Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e0/c29d9d462d7cfc5fc8f9bf24f9c6843b40e953c0b55e04eba2ad2cf54fba/multidict-6.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:169c4ba7858176b797fe551d6e99040c531c775d2d57b31bcf4de6d7a669847f", size = 224686, upload-time = "2025-05-19T14:14:48.366Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4a/da99398d7fd8210d9de068f9a1b5f96dfaf67d51e3f2521f17cba4ee1012/multidict-6.4.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b9eb4c59c54421a32b3273d4239865cb14ead53a606db066d7130ac80cc8ec93", size = 231061, upload-time = "2025-05-19T14:14:49.952Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f5/ac11add39a0f447ac89353e6ca46666847051103649831c08a2800a14455/multidict-6.4.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7cf3bd54c56aa16fdb40028d545eaa8d051402b61533c21e84046e05513d5780", size = 232412, upload-time = "2025-05-19T14:14:51.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/11/4b551e2110cded705a3c13a1d4b6a11f73891eb5a1c449f1b2b6259e58a6/multidict-6.4.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f682c42003c7264134bfe886376299db4cc0c6cd06a3295b41b347044bcb5482", size = 231563, upload-time = "2025-05-19T14:14:53.262Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/02/751530c19e78fe73b24c3da66618eda0aa0d7f6e7aa512e46483de6be210/multidict-6.4.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920f9cf2abdf6e493c519492d892c362007f113c94da4c239ae88429835bad1", size = 223811, upload-time = "2025-05-19T14:14:55.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cb/2be8a214643056289e51ca356026c7b2ce7225373e7a1f8c8715efee8988/multidict-6.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:530d86827a2df6504526106b4c104ba19044594f8722d3e87714e847c74a0275", size = 216524, upload-time = "2025-05-19T14:14:57.226Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f3/6d5011ec375c09081f5250af58de85f172bfcaafebff286d8089243c4bd4/multidict-6.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ecde56ea2439b96ed8a8d826b50c57364612ddac0438c39e473fafad7ae1c23b", size = 229012, upload-time = "2025-05-19T14:14:58.597Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9c/ca510785df5cf0eaf5b2a8132d7d04c1ce058dcf2c16233e596ce37a7f8e/multidict-6.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:dc8c9736d8574b560634775ac0def6bdc1661fc63fa27ffdfc7264c565bcb4f2", size = 226765, upload-time = "2025-05-19T14:15:00.048Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c8/ca86019994e92a0f11e642bda31265854e6ea7b235642f0477e8c2e25c1f/multidict-6.4.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7f3d3b3c34867579ea47cbd6c1f2ce23fbfd20a273b6f9e3177e256584f1eacc", size = 222888, upload-time = "2025-05-19T14:15:01.568Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/67/bc25a8e8bd522935379066950ec4e2277f9b236162a73548a2576d4b9587/multidict-6.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:87a728af265e08f96b6318ebe3c0f68b9335131f461efab2fc64cc84a44aa6ed", size = 234041, upload-time = "2025-05-19T14:15:03.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a0/70c4c2d12857fccbe607b334b7ee28b6b5326c322ca8f73ee54e70d76484/multidict-6.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9f193eeda1857f8e8d3079a4abd258f42ef4a4bc87388452ed1e1c4d2b0c8740", size = 231046, upload-time = "2025-05-19T14:15:05.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0f/52954601d02d39742aab01d6b92f53c1dd38b2392248154c50797b4df7f1/multidict-6.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be06e73c06415199200e9a2324a11252a3d62030319919cde5e6950ffeccf72e", size = 227106, upload-time = "2025-05-19T14:15:07.124Z" },
+    { url = "https://files.pythonhosted.org/packages/af/24/679d83ec4379402d28721790dce818e5d6b9f94ce1323a556fb17fa9996c/multidict-6.4.4-cp312-cp312-win32.whl", hash = "sha256:622f26ea6a7e19b7c48dd9228071f571b2fbbd57a8cd71c061e848f281550e6b", size = 35351, upload-time = "2025-05-19T14:15:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ef/40d98bc5f986f61565f9b345f102409534e29da86a6454eb6b7c00225a13/multidict-6.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:5e2bcda30d5009996ff439e02a9f2b5c3d64a20151d34898c000a6281faa3781", size = 38791, upload-time = "2025-05-19T14:15:09.825Z" },
+    { url = "https://files.pythonhosted.org/packages/84/5d/e17845bb0fa76334477d5de38654d27946d5b5d3695443987a094a71b440/multidict-6.4.4-py3-none-any.whl", hash = "sha256:bd4557071b561a8b3b6075c3ce93cf9bfb6182cb241805c3d66ced3b75eff4ac", size = 10481, upload-time = "2025-05-19T14:16:36.024Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload-time = "2024-01-28T18:52:34.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/7ec7fddc92e50714ea3745631f79bd9c96424cb2702632521028e57d3a36/multiprocess-0.70.16-py310-none-any.whl", hash = "sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02", size = 134824, upload-time = "2024-01-28T18:52:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/50/15/b56e50e8debaf439f44befec5b2af11db85f6e0f344c3113ae0be0593a91/multiprocess-0.70.16-py311-none-any.whl", hash = "sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a", size = 143519, upload-time = "2024-01-28T18:52:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload-time = "2024-01-28T18:52:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload-time = "2024-01-28T18:52:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload-time = "2024-01-28T18:52:31.981Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
+]
+
+[[package]]
+name = "ninja"
+version = "1.11.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/d4/6b0324541018561c5e73e617bd16f20a4fc17d1179bb3b3520b6ca8beb7b/ninja-1.11.1.4.tar.gz", hash = "sha256:6aa39f6e894e0452e5b297327db00019383ae55d5d9c57c73b04f13bf79d438a", size = 201256, upload-time = "2025-03-22T06:46:43.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/b1/3a61b348936b62a386465b1937cd778fa3a5748582e26d832dbab844ff27/ninja-1.11.1.4-py3-none-macosx_10_9_universal2.whl", hash = "sha256:b33923c8da88e8da20b6053e38deb433f53656441614207e01d283ad02c5e8e7", size = 279071, upload-time = "2025-03-22T06:46:17.806Z" },
+    { url = "https://files.pythonhosted.org/packages/12/42/4c94fdad51fcf1f039a156e97de9e4d564c2a8cc0303782d36f9bd893a4b/ninja-1.11.1.4-py3-none-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cede0af00b58e27b31f2482ba83292a8e9171cdb9acc2c867a3b6e40b3353e43", size = 472026, upload-time = "2025-03-22T06:46:19.974Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7a/455d2877fe6cf99886849c7f9755d897df32eaf3a0fba47b56e615f880f7/ninja-1.11.1.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:096487995473320de7f65d622c3f1d16c3ad174797602218ca8c967f51ec38a0", size = 422814, upload-time = "2025-03-22T06:46:21.235Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/fb6cca942528e25e8e0ab0f0cf98fe007319bf05cf69d726c564b815c4af/ninja-1.11.1.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3090d4488fadf6047d0d7a1db0c9643a8d391f0d94729554dbb89b5bdc769d7", size = 156965, upload-time = "2025-03-22T06:46:23.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e7/d94a1b60031b115dd88526834b3da69eaacdc3c1a6769773ca8e2b1386b5/ninja-1.11.1.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ecce44a00325a93631792974659cf253a815cc6da4ec96f89742925dfc295a0d", size = 179937, upload-time = "2025-03-22T06:46:24.728Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cc/e9316a28235409e9363794fc3d0b3083e48dd80d441006de66421e55f364/ninja-1.11.1.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c29bb66d2aa46a2409ab369ea804c730faec7652e8c22c1e428cc09216543e5", size = 157020, upload-time = "2025-03-22T06:46:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/30/389b22300541aa5f2e9dad322c4de2f84be4e32aa4e8babd9160d620b5f1/ninja-1.11.1.4-py3-none-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:055f386fb550c2c9d6157e45e20a84d29c47968876b9c5794ae2aec46f952306", size = 130389, upload-time = "2025-03-22T06:46:27.174Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/10/e27f35cb92813aabbb7ae771b1685b45be1cc8a0798ce7d4bfd08d142b93/ninja-1.11.1.4-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:f6186d7607bb090c3be1e10c8a56b690be238f953616626f5032238c66e56867", size = 372435, upload-time = "2025-03-22T06:46:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/26/e3559619756739aae124c6abf7fe41f7e546ab1209cfbffb13137bff2d2e/ninja-1.11.1.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:cf4453679d15babc04ba023d68d091bb613091b67101c88f85d2171c6621c6eb", size = 419300, upload-time = "2025-03-22T06:46:30.392Z" },
+    { url = "https://files.pythonhosted.org/packages/35/46/809e4e9572570991b8e6f88f3583807d017371ab4cb09171cbc72a7eb3e4/ninja-1.11.1.4-py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:d4a6f159b08b0ac4aca5ee1572e3e402f969139e71d85d37c0e2872129098749", size = 420239, upload-time = "2025-03-22T06:46:32.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/64/5cb5710d15f844edf02ada577f8eddfdcd116f47eec15850f3371a3a4b33/ninja-1.11.1.4-py3-none-musllinux_1_1_s390x.whl", hash = "sha256:c3b96bd875f3ef1db782470e9e41d7508905a0986571f219d20ffed238befa15", size = 415986, upload-time = "2025-03-22T06:46:33.821Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/0e9ab1d926f423b12b09925f78afcc5e48b3c22e7121be3ddf6c35bf06a3/ninja-1.11.1.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:cf554e73f72c04deb04d0cf51f5fdb1903d9c9ca3d2344249c8ce3bd616ebc02", size = 379657, upload-time = "2025-03-22T06:46:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/3e/fd6d330d0434168e7fe070d414b57dd99c4c133faa69c05b42a3cbdc6c13/ninja-1.11.1.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cfdd09776436a1ff3c4a2558d3fc50a689fb9d7f1bdbc3e6f7b8c2991341ddb3", size = 454466, upload-time = "2025-03-22T06:46:37.413Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/df/a25f3ad0b1c59d1b90564096e4fd89a6ca30d562b1e942f23880c3000b89/ninja-1.11.1.4-py3-none-win32.whl", hash = "sha256:2ab67a41c90bea5ec4b795bab084bc0b3b3bb69d3cd21ca0294fc0fc15a111eb", size = 255931, upload-time = "2025-03-22T06:46:39.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/10/9b8fe9ac004847490cc7b54896124c01ce2d87d95dc60aabd0b8591addff/ninja-1.11.1.4-py3-none-win_amd64.whl", hash = "sha256:4617b3c12ff64b611a7d93fd9e378275512bb36eff8babff7c83f5116b4f8d66", size = 296461, upload-time = "2025-03-22T06:46:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/58/612a17593c2d117f96c7f6b7f1e6570246bddc4b1e808519403a1417f217/ninja-1.11.1.4-py3-none-win_arm64.whl", hash = "sha256:5713cf50c5be50084a8693308a63ecf9e55c3132a78a41ab1363a28b6caaaee1", size = 271441, upload-time = "2025-03-22T06:46:42.147Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/db/8e12381333aea300890829a0a36bfa738cac95475d88982d538725143fd9/numpy-2.3.0.tar.gz", hash = "sha256:581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6", size = 20382813, upload-time = "2025-06-07T14:54:32.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/59/9df493df81ac6f76e9f05cdbe013cdb0c9a37b434f6e594f5bd25e278908/numpy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:389b85335838155a9076e9ad7f8fdba0827496ec2d2dc32ce69ce7898bde03ba", size = 20897025, upload-time = "2025-06-07T14:40:33.558Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/86/4ff04335901d6cf3a6bb9c748b0097546ae5af35e455ae9b962ebff4ecd7/numpy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9498f60cd6bb8238d8eaf468a3d5bb031d34cd12556af53510f05fcf581c1b7e", size = 14129882, upload-time = "2025-06-07T14:40:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8d/a942cd4f959de7f08a79ab0c7e6cecb7431d5403dce78959a726f0f57aa1/numpy-2.3.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:622a65d40d8eb427d8e722fd410ac3ad4958002f109230bc714fa551044ebae2", size = 5110181, upload-time = "2025-06-07T14:41:04.4Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5d/45850982efc7b2c839c5626fb67fbbc520d5b0d7c1ba1ae3651f2f74c296/numpy-2.3.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:b9446d9d8505aadadb686d51d838f2b6688c9e85636a0c3abaeb55ed54756459", size = 6647581, upload-time = "2025-06-07T14:41:14.695Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c0/c871d4a83f93b00373d3eebe4b01525eee8ef10b623a335ec262b58f4dc1/numpy-2.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:50080245365d75137a2bf46151e975de63146ae6d79f7e6bd5c0e85c9931d06a", size = 14262317, upload-time = "2025-06-07T14:41:35.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/bc47f5fa666d5ff4145254f9e618d56e6a4ef9b874654ca74c19113bb538/numpy-2.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c24bb4113c66936eeaa0dc1e47c74770453d34f46ee07ae4efd853a2ed1ad10a", size = 16633919, upload-time = "2025-06-07T14:42:00.622Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b4/65f48009ca0c9b76df5f404fccdea5a985a1bb2e34e97f21a17d9ad1a4ba/numpy-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4d8d294287fdf685281e671886c6dcdf0291a7c19db3e5cb4178d07ccf6ecc67", size = 15567651, upload-time = "2025-06-07T14:42:24.429Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/62/5367855a2018578e9334ed08252ef67cc302e53edc869666f71641cad40b/numpy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6295f81f093b7f5769d1728a6bd8bf7466de2adfa771ede944ce6711382b89dc", size = 18361723, upload-time = "2025-06-07T14:42:51.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/75/5baed8cd867eabee8aad1e74d7197d73971d6a3d40c821f1848b8fab8b84/numpy-2.3.0-cp312-cp312-win32.whl", hash = "sha256:e6648078bdd974ef5d15cecc31b0c410e2e24178a6e10bf511e0557eed0f2570", size = 6318285, upload-time = "2025-06-07T14:43:02.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/49/d5781eaa1a15acb3b3a3f49dc9e2ff18d92d0ce5c2976f4ab5c0a7360250/numpy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:0898c67a58cdaaf29994bc0e2c65230fd4de0ac40afaf1584ed0b02cd74c6fdd", size = 12732594, upload-time = "2025-06-07T14:43:21.071Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1c/6d343e030815c7c97a1f9fbad00211b47717c7fe446834c224bd5311e6f1/numpy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:bd8df082b6c4695753ad6193018c05aac465d634834dca47a3ae06d4bb22d9ea", size = 9891498, upload-time = "2025-06-07T14:43:36.332Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.6.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb", size = 393138322, upload-time = "2024-11-20T17:40:25.65Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.6.80"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/60/7b6497946d74bcf1de852a21824d63baad12cd417db4195fc1bfe59db953/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132", size = 8917980, upload-time = "2024-11-20T17:36:04.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/24/120ee57b218d9952c379d1e026c4479c9ece9997a4fb46303611ee48f038/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73", size = 8917972, upload-time = "2024-10-01T16:58:06.036Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.6.77"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/2e/46030320b5a80661e88039f59060d1790298b4718944a65a7f2aeda3d9e9/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53", size = 23650380, upload-time = "2024-10-01T17:00:14.643Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.6.77"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/23/e717c5ac26d26cf39a27fbc076240fad2e3b817e5889d671b67f4f9f49c5/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7", size = 897690, upload-time = "2024-11-20T17:35:30.697Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/62/65c05e161eeddbafeca24dc461f47de550d9fa8a7e04eb213e32b55cfd99/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8", size = 897678, upload-time = "2024-10-01T16:57:33.821Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.5.1.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
+    { url = "https://files.pythonhosted.org/packages/60/de/99ec247a07ea40c969d904fc14f3a356b3e2a704121675b75c366b694ee1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca", size = 200221622, upload-time = "2024-10-01T17:03:58.79Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.11.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/66/cc9876340ac68ae71b15c743ddb13f8b30d5244af344ec8322b449e35426/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159", size = 1142103, upload-time = "2024-11-20T17:42:11.83Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.7.77"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/1b/44a01c4e70933637c93e6e1a8063d1e998b50213a6b65ac5a9169c47e98e/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf", size = 56279010, upload-time = "2024-11-20T17:42:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/aa/2c7ff0b5ee02eaef890c0ce7d4f74bc30901871c5e45dee1ae6d0083cd80/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117", size = 56279000, upload-time = "2024-10-01T17:04:45.274Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/baba53585da791d043c10084cf9553e074548408e04ae884cfe9193bd484/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6", size = 158229780, upload-time = "2024-10-01T17:05:39.875Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ac/64c4316ba163e8217a99680c7605f779accffc6a4bcd0c778c12948d3707/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f", size = 216561357, upload-time = "2024-10-01T17:06:29.861Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.26.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/ca/f42388aed0fddd64ade7493dbba36e1f534d4e6fdbdd355c6a90030ae028/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6", size = 201319755, upload-time = "2025-03-13T00:29:55.296Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.6.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/d7/c5383e47c7e9bf1c99d5bd2a8c935af2b6d705ad831a7ec5c97db4d82f4f/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a", size = 19744971, upload-time = "2024-11-20T17:46:53.366Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.6.77"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2", size = 89276, upload-time = "2024-11-20T17:38:27.621Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/0d0c945463719429b7bd21dece907ad0bde437a2ff12b9b12fee94722ab0/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1", size = 89265, upload-time = "2024-10-01T17:00:38.172Z" },
+]
+
+[[package]]
+name = "onnx"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/60/e56e8ec44ed34006e6d4a73c92a04d9eea6163cc12440e35045aec069175/onnx-1.18.0.tar.gz", hash = "sha256:3d8dbf9e996629131ba3aa1afd1d8239b660d1f830c6688dd7e03157cccd6b9c", size = 12563009, upload-time = "2025-05-12T22:03:09.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/fe/16228aca685392a7114625b89aae98b2dc4058a47f0f467a376745efe8d0/onnx-1.18.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:521bac578448667cbb37c50bf05b53c301243ede8233029555239930996a625b", size = 18285770, upload-time = "2025-05-12T22:02:26.116Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/77/ba50a903a9b5e6f9be0fa50f59eb2fca4a26ee653375408fbc72c3acbf9f/onnx-1.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4da451bf1c5ae381f32d430004a89f0405bc57a8471b0bddb6325a5b334aa40", size = 17421291, upload-time = "2025-05-12T22:02:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/25ec2ba723ac62b99e8fed6d7b59094dadb15e38d4c007331cc9ae3dfa5f/onnx-1.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99afac90b4cdb1471432203c3c1f74e16549c526df27056d39f41a9a47cfb4af", size = 17584084, upload-time = "2025-05-12T22:02:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/2c253a36070fb43f340ff1d2c450df6a9ef50b938adcd105693fee43c4ee/onnx-1.18.0-cp312-cp312-win32.whl", hash = "sha256:ee159b41a3ae58d9c7341cf432fc74b96aaf50bd7bb1160029f657b40dc69715", size = 15734892, upload-time = "2025-05-12T22:02:35.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/92/048ba8fafe6b2b9a268ec2fb80def7e66c0b32ab2cae74de886981f05a27/onnx-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05", size = 15850336, upload-time = "2025-05-12T22:02:38.545Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/bbc4ffedd44165dcc407a51ea4c592802a5391ce3dc94aa5045350f64635/onnx-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:911b37d724a5d97396f3c2ef9ea25361c55cbc9aa18d75b12a52b620b67145af", size = 15823802, upload-time = "2025-05-12T22:02:42.037Z" },
+]
+
+[[package]]
+name = "openai"
+version = "1.86.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/7a/9ad4a61f1502f0e59d8c27fb629e28a63259a44d8d31cd2314e1534a2d9f/openai-1.86.0.tar.gz", hash = "sha256:c64d5b788359a8fdf69bd605ae804ce41c1ce2e78b8dd93e2542e0ee267f1e4b", size = 468272, upload-time = "2025-06-10T16:50:32.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/c1/dfb16b3432810fc9758564f9d1a4dbce6b93b7fb763ba57530c7fc48316d/openai-1.86.0-py3-none-any.whl", hash = "sha256:c8889c39410621fe955c230cc4c21bfe36ec887f4e60a957de05f507d7e1f349", size = 730296, upload-time = "2025-06-10T16:50:30.495Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893, upload-time = "2024-09-20T13:09:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475, upload-time = "2024-09-20T13:09:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645, upload-time = "2024-09-20T19:02:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445, upload-time = "2024-09-20T13:09:17.621Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235, upload-time = "2024-09-20T19:02:07.094Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756, upload-time = "2024-09-20T13:09:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248, upload-time = "2024-09-20T13:09:23.137Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "11.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz", hash = "sha256:a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6", size = 47026707, upload-time = "2025-04-12T17:50:03.289Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/40/052610b15a1b8961f52537cc8326ca6a881408bc2bdad0d852edeb6ed33b/pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f", size = 3190185, upload-time = "2025-04-12T17:48:00.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7e/b86dbd35a5f938632093dc40d1682874c33dcfe832558fc80ca56bfcb774/pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b", size = 3030306, upload-time = "2025-04-12T17:48:02.391Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/467a161f9ed53e5eab51a42923c33051bf8d1a2af4626ac04f5166e58e0c/pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d", size = 4416121, upload-time = "2025-04-12T17:48:04.554Z" },
+    { url = "https://files.pythonhosted.org/packages/62/73/972b7742e38ae0e2ac76ab137ca6005dcf877480da0d9d61d93b613065b4/pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4", size = 4501707, upload-time = "2025-04-12T17:48:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3a/427e4cb0b9e177efbc1a84798ed20498c4f233abde003c06d2650a6d60cb/pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d", size = 4522921, upload-time = "2025-04-12T17:48:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7c/d8b1330458e4d2f3f45d9508796d7caf0c0d3764c00c823d10f6f1a3b76d/pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4", size = 4612523, upload-time = "2025-04-12T17:48:11.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/65738384e0b1acf451de5a573d8153fe84103772d139e1e0bdf1596be2ea/pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443", size = 4587836, upload-time = "2025-04-12T17:48:13.592Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c5/e795c9f2ddf3debb2dedd0df889f2fe4b053308bb59a3cc02a0cd144d641/pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c", size = 4669390, upload-time = "2025-04-12T17:48:15.938Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ae/ca0099a3995976a9fce2f423166f7bff9b12244afdc7520f6ed38911539a/pillow-11.2.1-cp312-cp312-win32.whl", hash = "sha256:1d535df14716e7f8776b9e7fee118576d65572b4aad3ed639be9e4fa88a1cad3", size = 2332309, upload-time = "2025-04-12T17:48:17.885Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/18/24bff2ad716257fc03da964c5e8f05d9790a779a8895d6566e493ccf0189/pillow-11.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941", size = 2676768, upload-time = "2025-04-12T17:48:19.655Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bb/e8d656c9543276517ee40184aaa39dcb41e683bca121022f9323ae11b39d/pillow-11.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb", size = 2415087, upload-time = "2025-04-12T17:48:21.991Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/16/43264e4a779dd8588c21a70f0709665ee8f611211bdd2c87d952cfa7c776/propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168", size = 44139, upload-time = "2025-06-09T22:56:06.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/42/9ca01b0a6f48e81615dca4765a8f1dd2c057e0540f6116a27dc5ee01dfb6/propcache-0.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de106b6c84506b31c27168582cd3cb3000a6412c16df14a8628e5871ff83c10", size = 73674, upload-time = "2025-06-09T22:54:30.551Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6e/21293133beb550f9c901bbece755d582bfaf2176bee4774000bd4dd41884/propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154", size = 43570, upload-time = "2025-06-09T22:54:32.296Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c8/0393a0a3a2b8760eb3bde3c147f62b20044f0ddac81e9d6ed7318ec0d852/propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce26862344bdf836650ed2487c3d724b00fbfec4233a1013f597b78c1cb73615", size = 43094, upload-time = "2025-06-09T22:54:33.929Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2c/489afe311a690399d04a3e03b069225670c1d489eb7b044a566511c1c498/propcache-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca54bd347a253af2cf4544bbec232ab982f4868de0dd684246b67a51bc6b1db", size = 226958, upload-time = "2025-06-09T22:54:35.186Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ca/63b520d2f3d418c968bf596839ae26cf7f87bead026b6192d4da6a08c467/propcache-0.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55780d5e9a2ddc59711d727226bb1ba83a22dd32f64ee15594b9392b1f544eb1", size = 234894, upload-time = "2025-06-09T22:54:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/11/60/1d0ed6fff455a028d678df30cc28dcee7af77fa2b0e6962ce1df95c9a2a9/propcache-0.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c", size = 233672, upload-time = "2025-06-09T22:54:38.062Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/54fd5301ef38505ab235d98827207176a5c9b2aa61939b10a460ca53e123/propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee6f22b6eaa39297c751d0e80c0d3a454f112f5c6481214fcf4c092074cecd67", size = 224395, upload-time = "2025-06-09T22:54:39.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1a/89a40e0846f5de05fdc6779883bf46ba980e6df4d2ff8fb02643de126592/propcache-0.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ca3aee1aa955438c4dba34fc20a9f390e4c79967257d830f137bd5a8a32ed3b", size = 212510, upload-time = "2025-06-09T22:54:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/33/ca98368586c9566a6b8d5ef66e30484f8da84c0aac3f2d9aec6d31a11bd5/propcache-0.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4f30862869fa2b68380d677cc1c5fcf1e0f2b9ea0cf665812895c75d0ca3b8", size = 222949, upload-time = "2025-06-09T22:54:43.038Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/11/ace870d0aafe443b33b2f0b7efdb872b7c3abd505bfb4890716ad7865e9d/propcache-0.3.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b77ec3c257d7816d9f3700013639db7491a434644c906a2578a11daf13176251", size = 217258, upload-time = "2025-06-09T22:54:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d2/86fd6f7adffcfc74b42c10a6b7db721d1d9ca1055c45d39a1a8f2a740a21/propcache-0.3.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cab90ac9d3f14b2d5050928483d3d3b8fb6b4018893fc75710e6aa361ecb2474", size = 213036, upload-time = "2025-06-09T22:54:46.243Z" },
+    { url = "https://files.pythonhosted.org/packages/07/94/2d7d1e328f45ff34a0a284cf5a2847013701e24c2a53117e7c280a4316b3/propcache-0.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0b504d29f3c47cf6b9e936c1852246c83d450e8e063d50562115a6be6d3a2535", size = 227684, upload-time = "2025-06-09T22:54:47.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/05/37ae63a0087677e90b1d14710e532ff104d44bc1efa3b3970fff99b891dc/propcache-0.3.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ce2ac2675a6aa41ddb2a0c9cbff53780a617ac3d43e620f8fd77ba1c84dcfc06", size = 234562, upload-time = "2025-06-09T22:54:48.982Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7c/3f539fcae630408d0bd8bf3208b9a647ccad10976eda62402a80adf8fc34/propcache-0.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b4239611205294cc433845b914131b2a1f03500ff3c1ed093ed216b82621e1", size = 222142, upload-time = "2025-06-09T22:54:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d2/34b9eac8c35f79f8a962546b3e97e9d4b990c420ee66ac8255d5d9611648/propcache-0.3.2-cp312-cp312-win32.whl", hash = "sha256:df4a81b9b53449ebc90cc4deefb052c1dd934ba85012aa912c7ea7b7e38b60c1", size = 37711, upload-time = "2025-06-09T22:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/61/d582be5d226cf79071681d1b46b848d6cb03d7b70af7063e33a2787eaa03/propcache-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7046e79b989d7fe457bb755844019e10f693752d169076138abf17f31380800c", size = 41479, upload-time = "2025-06-09T22:54:53.234Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797, upload-time = "2025-05-28T19:25:54.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603, upload-time = "2025-05-28T19:25:41.198Z" },
+    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283, upload-time = "2025-05-28T19:25:44.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604, upload-time = "2025-05-28T19:25:45.702Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115, upload-time = "2025-05-28T19:25:47.128Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070, upload-time = "2025-05-28T19:25:50.036Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724, upload-time = "2025-05-28T19:25:53.926Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "20.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ee/a7810cb9f3d6e9238e61d312076a9859bf3668fd21c69744de9532383912/pyarrow-20.0.0.tar.gz", hash = "sha256:febc4a913592573c8d5805091a6c2b5064c8bd6e002131f01061797d91c783c1", size = 1125187, upload-time = "2025-04-27T12:34:23.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/d6/0c10e0d54f6c13eb464ee9b67a68b8c71bcf2f67760ef5b6fbcddd2ab05f/pyarrow-20.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:75a51a5b0eef32727a247707d4755322cb970be7e935172b6a3a9f9ae98404ba", size = 30815067, upload-time = "2025-04-27T12:29:44.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e2/04e9874abe4094a06fd8b0cbb0f1312d8dd7d707f144c2ec1e5e8f452ffa/pyarrow-20.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:211d5e84cecc640c7a3ab900f930aaff5cd2702177e0d562d426fb7c4f737781", size = 32297128, upload-time = "2025-04-27T12:29:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/31/fd/c565e5dcc906a3b471a83273039cb75cb79aad4a2d4a12f76cc5ae90a4b8/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ba3cf4182828be7a896cbd232aa8dd6a31bd1f9e32776cc3796c012855e1199", size = 41334890, upload-time = "2025-04-27T12:29:59.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a9/3bdd799e2c9b20c1ea6dc6fa8e83f29480a97711cf806e823f808c2316ac/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c3a01f313ffe27ac4126f4c2e5ea0f36a5fc6ab51f8726cf41fee4b256680bd", size = 42421775, upload-time = "2025-04-27T12:30:06.875Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f7/da98ccd86354c332f593218101ae56568d5dcedb460e342000bd89c49cc1/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a2791f69ad72addd33510fec7bb14ee06c2a448e06b649e264c094c5b5f7ce28", size = 40687231, upload-time = "2025-04-27T12:30:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1b/2168d6050e52ff1e6cefc61d600723870bf569cbf41d13db939c8cf97a16/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4250e28a22302ce8692d3a0e8ec9d9dde54ec00d237cff4dfa9c1fbf79e472a8", size = 42295639, upload-time = "2025-04-27T12:30:21.949Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/2d976c0c7158fd25591c8ca55aee026e6d5745a021915a1835578707feb3/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:89e030dc58fc760e4010148e6ff164d2f44441490280ef1e97a542375e41058e", size = 42908549, upload-time = "2025-04-27T12:30:29.551Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a9/dfb999c2fc6911201dcbf348247f9cc382a8990f9ab45c12eabfd7243a38/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6102b4864d77102dbbb72965618e204e550135a940c2534711d5ffa787df2a5a", size = 44557216, upload-time = "2025-04-27T12:30:36.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/9adee63dfa3911be2382fb4d92e4b2e7d82610f9d9f668493bebaa2af50f/pyarrow-20.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:96d6a0a37d9c98be08f5ed6a10831d88d52cac7b13f5287f1e0f625a0de8062b", size = 25660496, upload-time = "2025-04-27T12:30:42.809Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.11.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
+]
+
+[[package]]
+name = "pylate"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "pandas" },
+    { name = "sentence-transformers" },
+    { name = "sqlitedict" },
+    { name = "voyager" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/b1/1eed87db1993d933501899bcddd1896d5fd6bc6a2f393049c4e4e159730b/pylate-1.1.2.tar.gz", hash = "sha256:f4fe32e29e2afeb9781175bff75e2b418820790e6e0d1722b15bf0684559b462", size = 41600, upload-time = "2024-09-13T13:04:53.62Z" }
+
+[[package]]
+name = "pypdf"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/46/67de1d7a65412aa1c896e6b280829b70b57d203fadae6859b690006b8e0a/pypdf-5.6.0.tar.gz", hash = "sha256:a4b6538b77fc796622000db7127e4e58039ec5e6afd292f8e9bf42e2e985a749", size = 5023749, upload-time = "2025-06-01T12:19:40.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/8b/dc3a72d98c22be7a4cbd664ad14c5a3e6295c2dbdf572865ed61e24b5e38/pypdf-5.6.0-py3-none-any.whl", hash = "sha256:ca6bf446bfb0a2d8d71d6d6bb860798d864c36a29b3d9ae8d7fc7958c59f88e7", size = 304208, upload-time = "2025-06-01T12:19:38.003Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+]
+
+[[package]]
+name = "ragatouille"
+version = "0.0.9.post2"
+source = { editable = "." }
+dependencies = [
+    { name = "colbert-ai" },
+    { name = "einops" },
+    { name = "faiss-cpu" },
+    { name = "fast-pytorch-kmeans" },
+    { name = "llama-index" },
+    { name = "onnx" },
+    { name = "psutil" },
+    { name = "sentence-transformers" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "torch" },
+    { name = "voyager" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "batched" },
+    { name = "fastapi" },
+    { name = "llama-index" },
+    { name = "rerankers" },
+    { name = "uvicorn" },
+    { name = "voyager" },
+]
+api = [
+    { name = "batched" },
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
+train = [
+    { name = "pylate" },
+    { name = "rerankers" },
+    { name = "sentence-transformers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "batched", marker = "extra == 'all'", specifier = ">=0.1.2" },
+    { name = "batched", marker = "extra == 'api'", specifier = ">=0.1.2" },
+    { name = "colbert-ai", git = "https://github.com/stanford-futuredata/ColBERT.git" },
+    { name = "einops" },
+    { name = "faiss-cpu" },
+    { name = "fast-pytorch-kmeans" },
+    { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.114.1" },
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.114.1" },
+    { name = "llama-index" },
+    { name = "llama-index", marker = "extra == 'all'" },
+    { name = "onnx" },
+    { name = "psutil" },
+    { name = "pylate", marker = "extra == 'train'" },
+    { name = "rerankers", marker = "extra == 'all'" },
+    { name = "rerankers", marker = "extra == 'train'" },
+    { name = "sentence-transformers" },
+    { name = "sentence-transformers", marker = "extra == 'train'" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "torch", specifier = ">=1.13" },
+    { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.30.6" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30.6" },
+    { name = "voyager" },
+    { name = "voyager", marker = "extra == 'all'" },
+]
+provides-extras = ["all", "api", "train"]
+
+[[package]]
+name = "regex"
+version = "2024.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494, upload-time = "2024-11-06T20:12:31.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/30/9a87ce8336b172cc232a0db89a3af97929d06c11ceaa19d97d84fa90a8f8/regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:52fb28f528778f184f870b7cf8f225f5eef0a8f6e3778529bdd40c7b3920796a", size = 483781, upload-time = "2024-11-06T20:10:07.07Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e8/00008ad4ff4be8b1844786ba6636035f7ef926db5686e4c0f98093612add/regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9", size = 288455, upload-time = "2024-11-06T20:10:09.117Z" },
+    { url = "https://files.pythonhosted.org/packages/60/85/cebcc0aff603ea0a201667b203f13ba75d9fc8668fab917ac5b2de3967bc/regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:805e6b60c54bf766b251e94526ebad60b7de0c70f70a4e6210ee2891acb70bf2", size = 284759, upload-time = "2024-11-06T20:10:11.155Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/701a4b0585cb05472a4da28ee28fdfe155f3638f5e1ec92306d924e5faf0/regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b85c2530be953a890eaffde05485238f07029600e8f098cdf1848d414a8b45e4", size = 794976, upload-time = "2024-11-06T20:10:13.24Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/fa87e563bf5fee75db8915f7352e1887b1249126a1be4813837f5dbec965/regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb26437975da7dc36b7efad18aa9dd4ea569d2357ae6b783bf1118dabd9ea577", size = 833077, upload-time = "2024-11-06T20:10:15.37Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/56/7295e6bad94b047f4d0834e4779491b81216583c00c288252ef625c01d23/regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abfa5080c374a76a251ba60683242bc17eeb2c9818d0d30117b4486be10c59d3", size = 823160, upload-time = "2024-11-06T20:10:19.027Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/13/e3b075031a738c9598c51cfbc4c7879e26729c53aa9cca59211c44235314/regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b7fa6606c2881c1db9479b0eaa11ed5dfa11c8d60a474ff0e095099f39d98e", size = 796896, upload-time = "2024-11-06T20:10:21.85Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/0b3f1b66d592be6efec23a795b37732682520b47c53da5a32c33ed7d84e3/regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c32f75920cf99fe6b6c539c399a4a128452eaf1af27f39bce8909c9a3fd8cbe", size = 783997, upload-time = "2024-11-06T20:10:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/eb378dada8b91c0e4c5f08ffb56f25fcae47bf52ad18f9b2f33b83e6d498/regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:982e6d21414e78e1f51cf595d7f321dcd14de1f2881c5dc6a6e23bbbbd68435e", size = 781725, upload-time = "2024-11-06T20:10:28.067Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f2/033e7dec0cfd6dda93390089864732a3409246ffe8b042e9554afa9bff4e/regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a7c2155f790e2fb448faed6dd241386719802296ec588a8b9051c1f5c481bc29", size = 789481, upload-time = "2024-11-06T20:10:31.612Z" },
+    { url = "https://files.pythonhosted.org/packages/83/23/15d4552ea28990a74e7696780c438aadd73a20318c47e527b47a4a5a596d/regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149f5008d286636e48cd0b1dd65018548944e495b0265b45e1bffecce1ef7f39", size = 852896, upload-time = "2024-11-06T20:10:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/39/ed4416bc90deedbfdada2568b2cb0bc1fdb98efe11f5378d9892b2a88f8f/regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e5364a4502efca094731680e80009632ad6624084aff9a23ce8c8c6820de3e51", size = 860138, upload-time = "2024-11-06T20:10:36.142Z" },
+    { url = "https://files.pythonhosted.org/packages/93/2d/dd56bb76bd8e95bbce684326302f287455b56242a4f9c61f1bc76e28360e/regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0a86e7eeca091c09e021db8eb72d54751e527fa47b8d5787caf96d9831bd02ad", size = 787692, upload-time = "2024-11-06T20:10:38.394Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/31877a249ab7a5156758246b9c59539abbeba22461b7d8adc9e8475ff73e/regex-2024.11.6-cp312-cp312-win32.whl", hash = "sha256:32f9a4c643baad4efa81d549c2aadefaeba12249b2adc5af541759237eee1c54", size = 262135, upload-time = "2024-11-06T20:10:40.367Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/ad2d7de49a600cdb8dd78434a1aeffe28b9d6fc42eb36afab4a27ad23384/regex-2024.11.6-cp312-cp312-win_amd64.whl", hash = "sha256:a93c194e2df18f7d264092dc8539b8ffb86b45b899ab976aa15d48214138e81b", size = 273567, upload-time = "2024-11-06T20:10:43.467Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "rerankers"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/1e/3ed2026be7c135939905eac4f50d1bf8339180821c6757b2e91b83de2fa5/rerankers-0.10.0.tar.gz", hash = "sha256:b8e8b363abc4e9757151956949c27b197993c0a774437287a932f855afc17a73", size = 49679, upload-time = "2025-05-22T08:22:53.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ed/f3b81ca8743d69b95d679b95e6e1d22cb7cc678ae77c6a57827303a7e48c/rerankers-0.10.0-py3-none-any.whl", hash = "sha256:634a6befa130a245ed46022ade217ee482869448f01aae2051ed54d7d5bd2791", size = 53084, upload-time = "2025-05-22T08:22:52.022Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/7e/2d5d6ee7b40c0682315367ec7475693d110f512922d582fef1bd4a63adc3/safetensors-0.5.3.tar.gz", hash = "sha256:b6b0d6ecacec39a4fdd99cc19f4576f5219ce858e6fd8dbe7609df0b8dc56965", size = 67210, upload-time = "2025-02-26T09:15:13.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/ae/88f6c49dbd0cc4da0e08610019a3c78a7d390879a919411a410a1876d03a/safetensors-0.5.3-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bd20eb133db8ed15b40110b7c00c6df51655a2998132193de2f75f72d99c7073", size = 436917, upload-time = "2025-02-26T09:15:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/11f1b4a2f5d2ab7da34ecc062b0bc301f2be024d110a6466726bec8c055c/safetensors-0.5.3-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:21d01c14ff6c415c485616b8b0bf961c46b3b343ca59110d38d744e577f9cce7", size = 418419, upload-time = "2025-02-26T09:15:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9a/add3e6fef267658075c5a41573c26d42d80c935cdc992384dfae435feaef/safetensors-0.5.3-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11bce6164887cd491ca75c2326a113ba934be596e22b28b1742ce27b1d076467", size = 459493, upload-time = "2025-02-26T09:14:51.812Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5c/bf2cae92222513cc23b3ff85c4a1bb2811a2c3583ac0f8e8d502751de934/safetensors-0.5.3-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4a243be3590bc3301c821da7a18d87224ef35cbd3e5f5727e4e0728b8172411e", size = 472400, upload-time = "2025-02-26T09:14:53.549Z" },
+    { url = "https://files.pythonhosted.org/packages/58/11/7456afb740bd45782d0f4c8e8e1bb9e572f1bf82899fb6ace58af47b4282/safetensors-0.5.3-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8bd84b12b1670a6f8e50f01e28156422a2bc07fb16fc4e98bded13039d688a0d", size = 522891, upload-time = "2025-02-26T09:14:55.717Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3d/fe73a9d2ace487e7285f6e157afee2383bd1ddb911b7cb44a55cf812eae3/safetensors-0.5.3-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:391ac8cab7c829452175f871fcaf414aa1e292b5448bd02620f675a7f3e7abb9", size = 537694, upload-time = "2025-02-26T09:14:57.036Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f8/dae3421624fcc87a89d42e1898a798bc7ff72c61f38973a65d60df8f124c/safetensors-0.5.3-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cead1fa41fc54b1e61089fa57452e8834f798cb1dc7a09ba3524f1eb08e0317a", size = 471642, upload-time = "2025-02-26T09:15:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/20/1fbe16f9b815f6c5a672f5b760951e20e17e43f67f231428f871909a37f6/safetensors-0.5.3-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1077f3e94182d72618357b04b5ced540ceb71c8a813d3319f1aba448e68a770d", size = 502241, upload-time = "2025-02-26T09:14:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/18/8e108846b506487aa4629fe4116b27db65c3dde922de2c8e0cc1133f3f29/safetensors-0.5.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:799021e78287bac619c7b3f3606730a22da4cda27759ddf55d37c8db7511c74b", size = 638001, upload-time = "2025-02-26T09:15:05.79Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/c116111d8291af6c8c8a8b40628fe833b9db97d8141c2a82359d14d9e078/safetensors-0.5.3-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df26da01aaac504334644e1b7642fa000bfec820e7cef83aeac4e355e03195ff", size = 734013, upload-time = "2025-02-26T09:15:07.892Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/41fcc4d3b7de837963622e8610d998710705bbde9a8a17221d85e5d0baad/safetensors-0.5.3-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:32c3ef2d7af8b9f52ff685ed0bc43913cdcde135089ae322ee576de93eae5135", size = 670687, upload-time = "2025-02-26T09:15:09.979Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ad/2b113098e69c985a3d8fbda4b902778eae4a35b7d5188859b4a63d30c161/safetensors-0.5.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:37f1521be045e56fc2b54c606d4455573e717b2d887c579ee1dbba5f868ece04", size = 643147, upload-time = "2025-02-26T09:15:11.185Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/95aeb51d4246bd9a3242d3d8349c1112b4ee7611a4b40f0c5c93b05f001d/safetensors-0.5.3-cp38-abi3-win32.whl", hash = "sha256:cfc0ec0846dcf6763b0ed3d1846ff36008c6e7290683b61616c4b040f6a54ace", size = 296677, upload-time = "2025-02-26T09:15:16.554Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e2/b011c38e5394c4c18fb5500778a55ec43ad6106126e74723ffaee246f56e/safetensors-0.5.3-cp38-abi3-win_amd64.whl", hash = "sha256:836cbbc320b47e80acd40e44c8682db0e8ad7123209f69b093def21ec7cafd11", size = 308878, upload-time = "2025-02-26T09:15:14.99Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/3b/29fa87e76b1d7b3b77cc1fcbe82e6e6b8cd704410705b008822de530277c/scikit_learn-1.7.0.tar.gz", hash = "sha256:c01e869b15aec88e2cdb73d27f15bdbe03bce8e2fb43afbe77c45d399e73a5a3", size = 7178217, upload-time = "2025-06-05T22:02:46.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/3a/bffab14e974a665a3ee2d79766e7389572ffcaad941a246931c824afcdb2/scikit_learn-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c2c7243d34aaede0efca7a5a96d67fddaebb4ad7e14a70991b9abee9dc5c0379", size = 11646758, upload-time = "2025-06-05T22:02:09.51Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d8/f3249232fa79a70cb40595282813e61453c1e76da3e1a44b77a63dd8d0cb/scikit_learn-1.7.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:9f39f6a811bf3f15177b66c82cbe0d7b1ebad9f190737dcdef77cfca1ea3c19c", size = 10673971, upload-time = "2025-06-05T22:02:12.217Z" },
+    { url = "https://files.pythonhosted.org/packages/67/93/eb14c50533bea2f77758abe7d60a10057e5f2e2cdcf0a75a14c6bc19c734/scikit_learn-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63017a5f9a74963d24aac7590287149a8d0f1a0799bbe7173c0d8ba1523293c0", size = 11818428, upload-time = "2025-06-05T22:02:14.947Z" },
+    { url = "https://files.pythonhosted.org/packages/08/17/804cc13b22a8663564bb0b55fb89e661a577e4e88a61a39740d58b909efe/scikit_learn-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b2f8a0b1e73e9a08b7cc498bb2aeab36cdc1f571f8ab2b35c6e5d1c7115d97d", size = 12505887, upload-time = "2025-06-05T22:02:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c7/4e956281a077f4835458c3f9656c666300282d5199039f26d9de1dabd9be/scikit_learn-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:34cc8d9d010d29fb2b7cbcd5ccc24ffdd80515f65fe9f1e4894ace36b267ce19", size = 10668129, upload-time = "2025-06-05T22:02:20.536Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/fb/2368f84127920d86330b533792e66b26264e92b729b5c1998aaa33d2e22f/sentence_transformers-3.0.1.tar.gz", hash = "sha256:8a3d2c537cc4d1014ccc20ac92be3d6135420a3bc60ae29a3a8a9b4bb35fbff6", size = 177258, upload-time = "2024-06-07T13:01:12.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4b/922436953394e1bfda05e4bf1fe0e80f609770f256c59a9df7a9254f3e0d/sentence_transformers-3.0.1-py3-none-any.whl", hash = "sha256:01050cc4053c49b9f5b78f6980b5a72db3fd3a0abb9169b1792ac83875505ee6", size = 227071, upload-time = "2024-06-07T13:01:10.063Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/2a/f1f4e068b371154740dd10fb81afb5240d5af4aa0087b88d8b308b5429c2/sqlalchemy-2.0.41-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:81f413674d85cfd0dfcd6512e10e0f33c19c21860342a4890c3a2b59479929f9", size = 2119645, upload-time = "2025-05-14T17:55:24.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/c664a7e73d36fbfc4730f8cf2bf930444ea87270f2825efbe17bf808b998/sqlalchemy-2.0.41-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:598d9ebc1e796431bbd068e41e4de4dc34312b7aa3292571bb3674a0cb415dd1", size = 2107399, upload-time = "2025-05-14T17:55:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/78/8a9cf6c5e7135540cb682128d091d6afa1b9e48bd049b0d691bf54114f70/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a104c5694dfd2d864a6f91b0956eb5d5883234119cb40010115fd45a16da5e70", size = 3293269, upload-time = "2025-05-14T17:50:38.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/f74add3978c20de6323fb11cb5162702670cc7a9420033befb43d8d5b7a4/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6145afea51ff0af7f2564a05fa95eb46f542919e6523729663a5d285ecb3cf5e", size = 3303364, upload-time = "2025-05-14T17:51:49.829Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d4/c990f37f52c3f7748ebe98883e2a0f7d038108c2c5a82468d1ff3eec50b7/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b46fa6eae1cd1c20e6e6f44e19984d438b6b2d8616d21d783d150df714f44078", size = 3229072, upload-time = "2025-05-14T17:50:39.774Z" },
+    { url = "https://files.pythonhosted.org/packages/15/69/cab11fecc7eb64bc561011be2bd03d065b762d87add52a4ca0aca2e12904/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41836fe661cc98abfae476e14ba1906220f92c4e528771a8a3ae6a151242d2ae", size = 3268074, upload-time = "2025-05-14T17:51:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/0c19ec16858585d37767b167fc9602593f98998a68a798450558239fb04a/sqlalchemy-2.0.41-cp312-cp312-win32.whl", hash = "sha256:a8808d5cf866c781150d36a3c8eb3adccfa41a8105d031bf27e92c251e3969d6", size = 2084514, upload-time = "2025-05-14T17:55:49.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/23/4c2833d78ff3010a4e17f984c734f52b531a8c9060a50429c9d4b0211be6/sqlalchemy-2.0.41-cp312-cp312-win_amd64.whl", hash = "sha256:5b14e97886199c1f52c14629c11d90c11fbb09e9334fa7bb5f6d068d9ced0ce0", size = 2111557, upload-time = "2025-05-14T17:55:51.349Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "sqlitedict"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/9a/7620d1e9dcb02839ed6d4b14064e609cdd7a8ae1e47289aa0456796dd9ca/sqlitedict-2.1.0.tar.gz", hash = "sha256:03d9cfb96d602996f1d4c2db2856f1224b96a9c431bdd16e78032a72940f9e8c", size = 21846, upload-time = "2022-12-03T13:39:13.102Z" }
+
+[[package]]
+name = "srsly"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/eb51b1349f50bac0222398af0942613fdc9d1453ae67cbe4bf9936a1a54b/srsly-2.5.1.tar.gz", hash = "sha256:ab1b4bf6cf3e29da23dae0493dd1517fb787075206512351421b89b4fc27c77e", size = 466464, upload-time = "2025-01-17T09:26:26.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f6/bebc20d75bd02121fc0f65ad8c92a5dd2570e870005e940faa55a263e61a/srsly-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:683b54ed63d7dfee03bc2abc4b4a5f2152f81ec217bbadbac01ef1aaf2a75790", size = 636717, upload-time = "2025-01-17T09:25:40.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e8/9372317a4742c70b87b413335adfcdfb2bee4f88f3faba89fabb9e6abf21/srsly-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:459d987130e57e83ce9e160899afbeb871d975f811e6958158763dd9a8a20f23", size = 634697, upload-time = "2025-01-17T09:25:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/00/c6a7b99ab27b051a27bd26fe1a8c1885225bb8980282bf9cb99f70610368/srsly-2.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:184e3c98389aab68ff04aab9095bd5f1a8e5a72cc5edcba9d733bac928f5cf9f", size = 1134655, upload-time = "2025-01-17T09:25:45.238Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/861459e8241ec3b78c111081bd5efa414ef85867e17c45b6882954468d6e/srsly-2.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c2a3e4856e63b7efd47591d049aaee8e5a250e098917f50d93ea68853fab78", size = 1143544, upload-time = "2025-01-17T09:25:47.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/85/8448fe874dd2042a4eceea5315cfff3af03ac77ff5073812071852c4e7e2/srsly-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:366b4708933cd8d6025c13c2cea3331f079c7bb5c25ec76fca392b6fc09818a0", size = 1098330, upload-time = "2025-01-17T09:25:52.55Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/04d0e1417da140b2ac4053a3d4fcfc86cd59bf4829f69d370bb899f74d5d/srsly-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8a0b03c64eb6e150d772c5149befbadd981cc734ab13184b0561c17c8cef9b1", size = 1110670, upload-time = "2025-01-17T09:25:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1a/a8cd627eaa81a91feb6ceab50155f4ceff3eef6107916cb87ef796958427/srsly-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:7952538f6bba91b9d8bf31a642ac9e8b9ccc0ccbb309feb88518bfb84bb0dc0d", size = 632598, upload-time = "2025-01-17T09:25:55.499Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+]
+
+[[package]]
+name = "striprtf"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/20/3d419008265346452d09e5dadfd5d045b64b40d8fc31af40588e6c76997a/striprtf-0.0.26.tar.gz", hash = "sha256:fdb2bba7ac440072d1c41eab50d8d74ae88f60a8b6575c6e2c7805dc462093aa", size = 6258, upload-time = "2023-07-20T14:30:36.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/cf/0fea4f4ba3fc2772ac2419278aa9f6964124d4302117d61bc055758e000c/striprtf-0.0.26-py3-none-any.whl", hash = "sha256:8c8f9d32083cdc2e8bfb149455aa1cc5a4e0a035893bedc75db8b73becb3a1bb", size = 6914, upload-time = "2023-07-20T14:30:35.338Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/cf/756fedf6981e82897f2d570dd25fa597eb3f4459068ae0572d7e888cfd6f/tiktoken-0.9.0.tar.gz", hash = "sha256:d02a5ca6a938e0490e1ff957bc48c8b078c88cb83977be1625b1fd8aac792c5d", size = 35991, upload-time = "2025-02-14T06:03:01.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/e5/21ff33ecfa2101c1bb0f9b6df750553bd873b7fb532ce2cb276ff40b197f/tiktoken-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e88f121c1c22b726649ce67c089b90ddda8b9662545a8aeb03cfef15967ddd03", size = 1065073, upload-time = "2025-02-14T06:02:24.768Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/03/a95e7b4863ee9ceec1c55983e4cc9558bcfd8f4f80e19c4f8a99642f697d/tiktoken-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a6600660f2f72369acb13a57fb3e212434ed38b045fd8cc6cdd74947b4b5d210", size = 1008075, upload-time = "2025-02-14T06:02:26.92Z" },
+    { url = "https://files.pythonhosted.org/packages/40/10/1305bb02a561595088235a513ec73e50b32e74364fef4de519da69bc8010/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95e811743b5dfa74f4b227927ed86cbc57cad4df859cb3b643be797914e41794", size = 1140754, upload-time = "2025-02-14T06:02:28.124Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/40/da42522018ca496432ffd02793c3a72a739ac04c3794a4914570c9bb2925/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99376e1370d59bcf6935c933cb9ba64adc29033b7e73f5f7569f3aad86552b22", size = 1196678, upload-time = "2025-02-14T06:02:29.845Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/41/1e59dddaae270ba20187ceb8aa52c75b24ffc09f547233991d5fd822838b/tiktoken-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:badb947c32739fb6ddde173e14885fb3de4d32ab9d8c591cbd013c22b4c31dd2", size = 1259283, upload-time = "2025-02-14T06:02:33.838Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/64/b16003419a1d7728d0d8c0d56a4c24325e7b10a21a9dd1fc0f7115c02f0a/tiktoken-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:5a62d7a25225bafed786a524c1b9f0910a1128f4232615bf3f8257a73aaa3b16", size = 894897, upload-time = "2025-02-14T06:02:36.265Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/76/5ac0c97f1117b91b7eb7323dcd61af80d72f790b4df71249a7850c195f30/tokenizers-0.21.1.tar.gz", hash = "sha256:a1bb04dc5b448985f86ecd4b05407f5a8d97cb2c0532199b2a302a604a0165ab", size = 343256, upload-time = "2025-03-13T10:51:18.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/1f/328aee25f9115bf04262e8b4e5a2050b7b7cf44b59c74e982db7270c7f30/tokenizers-0.21.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e78e413e9e668ad790a29456e677d9d3aa50a9ad311a40905d6861ba7692cf41", size = 2780767, upload-time = "2025-03-13T10:51:09.459Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1a/4526797f3719b0287853f12c5ad563a9be09d446c44ac784cdd7c50f76ab/tokenizers-0.21.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:cd51cd0a91ecc801633829fcd1fda9cf8682ed3477c6243b9a095539de4aecf3", size = 2650555, upload-time = "2025-03-13T10:51:07.692Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/7a/a209b29f971a9fdc1da86f917fe4524564924db50d13f0724feed37b2a4d/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28da6b72d4fb14ee200a1bd386ff74ade8992d7f725f2bde2c495a9a98cf4d9f", size = 2937541, upload-time = "2025-03-13T10:50:56.679Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1e/b788b50ffc6191e0b1fc2b0d49df8cff16fe415302e5ceb89f619d12c5bc/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:34d8cfde551c9916cb92014e040806122295a6800914bab5865deb85623931cf", size = 2819058, upload-time = "2025-03-13T10:50:59.525Z" },
+    { url = "https://files.pythonhosted.org/packages/36/aa/3626dfa09a0ecc5b57a8c58eeaeb7dd7ca9a37ad9dd681edab5acd55764c/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aaa852d23e125b73d283c98f007e06d4595732104b65402f46e8ef24b588d9f8", size = 3133278, upload-time = "2025-03-13T10:51:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/4d/8fbc203838b3d26269f944a89459d94c858f5b3f9a9b6ee9728cdcf69161/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a21a15d5c8e603331b8a59548bbe113564136dc0f5ad8306dd5033459a226da0", size = 3144253, upload-time = "2025-03-13T10:51:01.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1b/2bd062adeb7c7511b847b32e356024980c0ffcf35f28947792c2d8ad2288/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2fdbd4c067c60a0ac7eca14b6bd18a5bebace54eb757c706b47ea93204f7a37c", size = 3398225, upload-time = "2025-03-13T10:51:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/63/38be071b0c8e06840bc6046991636bcb30c27f6bb1e670f4f4bc87cf49cc/tokenizers-0.21.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dd9a0061e403546f7377df940e866c3e678d7d4e9643d0461ea442b4f89e61a", size = 3038874, upload-time = "2025-03-13T10:51:06.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/83/afa94193c09246417c23a3c75a8a0a96bf44ab5630a3015538d0c316dd4b/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:db9484aeb2e200c43b915a1a0150ea885e35f357a5a8fabf7373af333dcc8dbf", size = 9014448, upload-time = "2025-03-13T10:51:10.927Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b3/0e1a37d4f84c0f014d43701c11eb8072704f6efe8d8fc2dcdb79c47d76de/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:ed248ab5279e601a30a4d67bdb897ecbe955a50f1e7bb62bd99f07dd11c2f5b6", size = 8937877, upload-time = "2025-03-13T10:51:12.688Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/ff08f50e6d615eb180a4a328c65907feb6ded0b8f990ec923969759dc379/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:9ac78b12e541d4ce67b4dfd970e44c060a2147b9b2a21f509566d556a509c67d", size = 9186645, upload-time = "2025-03-13T10:51:14.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/aa/8ae85f69a9f6012c6f8011c6f4aa1c96154c816e9eea2e1b758601157833/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5a69c1a4496b81a5ee5d2c1f3f7fbdf95e90a0196101b0ee89ed9956b8a168f", size = 9384380, upload-time = "2025-03-13T10:51:16.526Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5b/a5d98c89f747455e8b7a9504910c865d5e51da55e825a7ae641fb5ff0a58/tokenizers-0.21.1-cp39-abi3-win32.whl", hash = "sha256:1039a3a5734944e09de1d48761ade94e00d0fa760c0e0551151d4dd851ba63e3", size = 2239506, upload-time = "2025-03-13T10:51:20.643Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b6/072a8e053ae600dcc2ac0da81a23548e3b523301a442a6ca900e92ac35be/tokenizers-0.21.1-cp39-abi3-win_amd64.whl", hash = "sha256:0f0dcbcc9f6e13e675a66d7a5f2f225a736745ce484c1a4e07476a89ccdad382", size = 2435481, upload-time = "2025-03-13T10:51:19.243Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/93/fb505a5022a2e908d81fe9a5e0aa84c86c0d5f408173be71c6018836f34e/torch-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ea1e518df4c9de73af7e8a720770f3628e7f667280bce2be7a16292697e3fa", size = 98948276, upload-time = "2025-06-04T17:39:12.852Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7e/67c3fe2b8c33f40af06326a3d6ae7776b3e3a01daa8f71d125d78594d874/torch-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c33360cfc2edd976c2633b3b66c769bdcbbf0e0b6550606d188431c81e7dd1fc", size = 821025792, upload-time = "2025-06-04T17:34:58.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/a37495502bc7a23bf34f89584fa5a78e25bae7b8da513bc1b8f97afb7009/torch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8bf6e1856ddd1807e79dc57e54d3335f2b62e6f316ed13ed3ecfe1fc1df3d8b", size = 216050349, upload-time = "2025-06-04T17:38:59.709Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/04b77281c730bb13460628e518c52721257814ac6c298acd25757f6a175c/torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb", size = 68645146, upload-time = "2025-06-04T17:38:52.97Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/a9/275037087f9d846580b02f2d7cae0e0a6955d46f84583d0151d6227bd416/transformers-4.52.4.tar.gz", hash = "sha256:aff3764441c1adc192a08dba49740d3cbbcb72d850586075aed6bd89b98203e6", size = 8945376, upload-time = "2025-05-30T09:17:17.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/f2/25b27b396af03d5b64e61976b14f7209e2939e9e806c10749b6d277c273e/transformers-4.52.4-py3-none-any.whl", hash = "sha256:203f5c19416d5877e36e88633943761719538a25d9775977a24fe77a1e5adfc7", size = 10460375, upload-time = "2025-05-30T09:17:14.477Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/5f/950fb373bf9c01ad4eb5a8cd5eaf32cdf9e238c02f9293557a2129b9c4ac/triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43", size = 155669138, upload-time = "2025-05-29T23:39:51.771Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839, upload-time = "2025-06-02T14:52:10.026Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "ujson"
+version = "5.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/00/3110fd566786bfa542adb7932d62035e0c0ef662a8ff6544b6643b3d6fd7/ujson-5.10.0.tar.gz", hash = "sha256:b3cd8f3c5d8c7738257f1018880444f7b7d9b66232c64649f562d7ba86ad4bc1", size = 7154885, upload-time = "2024-05-14T02:02:34.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/a6/fd3f8bbd80842267e2d06c3583279555e8354c5986c952385199d57a5b6c/ujson-5.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:98ba15d8cbc481ce55695beee9f063189dce91a4b08bc1d03e7f0152cd4bbdd5", size = 55642, upload-time = "2024-05-14T02:01:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/47/dd03fd2b5ae727e16d5d18919b383959c6d269c7b948a380fdd879518640/ujson-5.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9d2edbf1556e4f56e50fab7d8ff993dbad7f54bac68eacdd27a8f55f433578e", size = 51807, upload-time = "2024-05-14T02:01:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/25/23/079a4cc6fd7e2655a473ed9e776ddbb7144e27f04e8fc484a0fb45fe6f71/ujson-5.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6627029ae4f52d0e1a2451768c2c37c0c814ffc04f796eb36244cf16b8e57043", size = 51972, upload-time = "2024-05-14T02:01:06.458Z" },
+    { url = "https://files.pythonhosted.org/packages/04/81/668707e5f2177791869b624be4c06fb2473bf97ee33296b18d1cf3092af7/ujson-5.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8ccb77b3e40b151e20519c6ae6d89bfe3f4c14e8e210d910287f778368bb3d1", size = 53686, upload-time = "2024-05-14T02:01:07.618Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/50/056d518a386d80aaf4505ccf3cee1c40d312a46901ed494d5711dd939bc3/ujson-5.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3caf9cd64abfeb11a3b661329085c5e167abbe15256b3b68cb5d914ba7396f3", size = 58591, upload-time = "2024-05-14T02:01:08.901Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d6/aeaf3e2d6fb1f4cfb6bf25f454d60490ed8146ddc0600fae44bfe7eb5a72/ujson-5.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6e32abdce572e3a8c3d02c886c704a38a1b015a1fb858004e03d20ca7cecbb21", size = 997853, upload-time = "2024-05-14T02:01:10.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/1f2a5d2699f447f7d990334ca96e90065ea7f99b142ce96e85f26d7e78e2/ujson-5.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a65b6af4d903103ee7b6f4f5b85f1bfd0c90ba4eeac6421aae436c9988aa64a2", size = 1140689, upload-time = "2024-05-14T02:01:12.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2c/6990f4ccb41ed93744aaaa3786394bca0875503f97690622f3cafc0adfde/ujson-5.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:604a046d966457b6cdcacc5aa2ec5314f0e8c42bae52842c1e6fa02ea4bda42e", size = 1043576, upload-time = "2024-05-14T02:01:14.39Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f5/a2368463dbb09fbdbf6a696062d0c0f62e4ae6fa65f38f829611da2e8fdd/ujson-5.10.0-cp312-cp312-win32.whl", hash = "sha256:6dea1c8b4fc921bf78a8ff00bbd2bfe166345f5536c510671bccececb187c80e", size = 38764, upload-time = "2024-05-14T02:01:15.83Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2d/691f741ffd72b6c84438a93749ac57bf1a3f217ac4b0ea4fd0e96119e118/ujson-5.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:38665e7d8290188b1e0d57d584eb8110951a9591363316dd41cf8686ab1d0abc", size = 42211, upload-time = "2024-05-14T02:01:17.567Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
+]
+
+[[package]]
+name = "voyager"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c1/57d37108b0cc892314286c221ed9ffe0540768e0f1c5ac583ea6e14d8d9a/voyager-2.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:18ef1903fa85a2ff580f1d5a70f62c1eee710d39487eeeb192f34555cb50be6e", size = 702332, upload-time = "2024-12-13T19:50:55.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/94/73002811f8c542d138952d3485bab94b2e280cf4ddf7fd901e1ac6884254/voyager-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dc23adf051720560cf9f5a958df155edaba6f7b2c3746a1686f92bbc9b846d15", size = 362635, upload-time = "2024-12-13T19:50:57.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/3b/770117e65710f22fdbc575072c43824f1526bdb1d000f5089bef5bd4a650/voyager-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b75034984411ed3120b919f4d7f16ed0406bb5863924a28525b48ac5b4010fa", size = 339880, upload-time = "2024-12-13T19:51:00.123Z" },
+    { url = "https://files.pythonhosted.org/packages/91/87/f3ed4ebeeff371b0b759c277025379dbcb5dbf00083df6c03f5c9727b6cd/voyager-2.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf5359d8a88bd5fc12fc71c0e7fd332e4da1d96dac8ae445b0138871cd28b2", size = 4360919, upload-time = "2024-12-13T19:51:02.516Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/a772a9a2d4cc427f6b4ae2aca65e50ec99f7bb6037c346cc22a07bc4a326/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9415b9c923bac493d5c68d55ae55c4289153c23f9f478422934de61acbaf4c01", size = 4444514, upload-time = "2024-12-13T19:51:04.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/76/02b66dc8c1e9d373327ef15ff3ccdea5be0b104d43d65c8bf52848058331/voyager-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f8264f438f1df40d11e1f18a069980972a569f5a2f3c0a0d2abef9d4b4078d5c", size = 207456, upload-time = "2024-12-13T19:51:05.582Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531, upload-time = "2025-01-14T10:35:45.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799, upload-time = "2025-01-14T10:33:57.4Z" },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821, upload-time = "2025-01-14T10:33:59.334Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919, upload-time = "2025-01-14T10:34:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721, upload-time = "2025-01-14T10:34:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899, upload-time = "2025-01-14T10:34:09.82Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222, upload-time = "2025-01-14T10:34:11.258Z" },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707, upload-time = "2025-01-14T10:34:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685, upload-time = "2025-01-14T10:34:15.043Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567, upload-time = "2025-01-14T10:34:16.563Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672, upload-time = "2025-01-14T10:34:17.727Z" },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865, upload-time = "2025-01-14T10:34:19.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload-time = "2025-01-14T10:35:44.018Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/5e/d6e5258d69df8b4ed8c83b6664f2b47d30d2dec551a29ad72a6c69eafd31/xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f", size = 84241, upload-time = "2024-08-17T09:20:38.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/0e/1bfce2502c57d7e2e787600b31c83535af83746885aa1a5f153d8c8059d6/xxhash-3.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:14470ace8bd3b5d51318782cd94e6f94431974f16cb3b8dc15d52f3b69df8e00", size = 31969, upload-time = "2024-08-17T09:18:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/8ca450d6fe5b71ce521b4e5db69622383d039e2b253e9b2f24f93265b52c/xxhash-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59aa1203de1cb96dbeab595ded0ad0c0056bb2245ae11fac11c0ceea861382b9", size = 30787, upload-time = "2024-08-17T09:18:25.318Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/de7c89bc6ef63d750159086a6ada6416cc4349eab23f76ab870407178b93/xxhash-3.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08424f6648526076e28fae6ea2806c0a7d504b9ef05ae61d196d571e5c879c84", size = 220959, upload-time = "2024-08-17T09:18:26.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/51258d3e8a8545ff26468c977101964c14d56a8a37f5835bc0082426c672/xxhash-3.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a1ff00674879725b194695e17f23d3248998b843eb5e933007ca743310f793", size = 200006, upload-time = "2024-08-17T09:18:27.905Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0a/96973bd325412feccf23cf3680fd2246aebf4b789122f938d5557c54a6b2/xxhash-3.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f2c61bee5844d41c3eb015ac652a0229e901074951ae48581d58bfb2ba01be", size = 428326, upload-time = "2024-08-17T09:18:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a7/81dba5010f7e733de88af9555725146fc133be97ce36533867f4c7e75066/xxhash-3.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d32a592cac88d18cc09a89172e1c32d7f2a6e516c3dfde1b9adb90ab5df54a6", size = 194380, upload-time = "2024-08-17T09:18:30.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7d/f29006ab398a173f4501c0e4977ba288f1c621d878ec217b4ff516810c04/xxhash-3.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70dabf941dede727cca579e8c205e61121afc9b28516752fd65724be1355cc90", size = 207934, upload-time = "2024-08-17T09:18:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6e/6e88b8f24612510e73d4d70d9b0c7dff62a2e78451b9f0d042a5462c8d03/xxhash-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e5d0ddaca65ecca9c10dcf01730165fd858533d0be84c75c327487c37a906a27", size = 216301, upload-time = "2024-08-17T09:18:33.474Z" },
+    { url = "https://files.pythonhosted.org/packages/af/51/7862f4fa4b75a25c3b4163c8a873f070532fe5f2d3f9b3fc869c8337a398/xxhash-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e5b5e16c5a480fe5f59f56c30abdeba09ffd75da8d13f6b9b6fd224d0b4d0a2", size = 203351, upload-time = "2024-08-17T09:18:34.889Z" },
+    { url = "https://files.pythonhosted.org/packages/22/61/8d6a40f288f791cf79ed5bb113159abf0c81d6efb86e734334f698eb4c59/xxhash-3.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149b7914451eb154b3dfaa721315117ea1dac2cc55a01bfbd4df7c68c5dd683d", size = 210294, upload-time = "2024-08-17T09:18:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/17/02/215c4698955762d45a8158117190261b2dbefe9ae7e5b906768c09d8bc74/xxhash-3.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:eade977f5c96c677035ff39c56ac74d851b1cca7d607ab3d8f23c6b859379cab", size = 414674, upload-time = "2024-08-17T09:18:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/b7a8db8a3237cff3d535261325d95de509f6a8ae439a5a7a4ffcff478189/xxhash-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa9f547bd98f5553d03160967866a71056a60960be00356a15ecc44efb40ba8e", size = 192022, upload-time = "2024-08-17T09:18:40.138Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e3/dd76659b2811b3fd06892a8beb850e1996b63e9235af5a86ea348f053e9e/xxhash-3.5.0-cp312-cp312-win32.whl", hash = "sha256:f7b58d1fd3551b8c80a971199543379be1cee3d0d409e1f6d8b01c1a2eebf1f8", size = 30170, upload-time = "2024-08-17T09:18:42.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6b/1c443fe6cfeb4ad1dcf231cdec96eb94fb43d6498b4469ed8b51f8b59a37/xxhash-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa0cafd3a2af231b4e113fba24a65d7922af91aeb23774a8b78228e6cd785e3e", size = 30040, upload-time = "2024-08-17T09:18:43.699Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/eb/04405305f290173acc0350eba6d2f1a794b57925df0398861a20fbafa415/xxhash-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:586886c7e89cb9828bcd8a5686b12e161368e0064d040e225e72607b43858ba2", size = 26796, upload-time = "2024-08-17T09:18:45.29Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fb/efaa23fa4e45537b827620f04cf8f3cd658b76642205162e072703a5b963/yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac", size = 186428, upload-time = "2025-06-10T00:46:09.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/9a/cb7fad7d73c69f296eda6815e4a2c7ed53fc70c2f136479a91c8e5fbdb6d/yarl-1.20.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdcc4cd244e58593a4379fe60fdee5ac0331f8eb70320a24d591a3be197b94a9", size = 133667, upload-time = "2025-06-10T00:43:44.369Z" },
+    { url = "https://files.pythonhosted.org/packages/67/38/688577a1cb1e656e3971fb66a3492501c5a5df56d99722e57c98249e5b8a/yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b29a2c385a5f5b9c7d9347e5812b6f7ab267193c62d282a540b4fc528c8a9d2a", size = 91025, upload-time = "2025-06-10T00:43:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1112ae8154186dfe2de4732197f59c05a83dc814849a5ced892b708033f40dc2", size = 89709, upload-time = "2025-06-10T00:43:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/99/da/4d798025490e89426e9f976702e5f9482005c548c579bdae792a4c37769e/yarl-1.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90bbd29c4fe234233f7fa2b9b121fb63c321830e5d05b45153a2ca68f7d310ee", size = 352287, upload-time = "2025-06-10T00:43:49.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/26/54a15c6a567aac1c61b18aa0f4b8aa2e285a52d547d1be8bf48abe2b3991/yarl-1.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:680e19c7ce3710ac4cd964e90dad99bf9b5029372ba0c7cbfcd55e54d90ea819", size = 345429, upload-time = "2025-06-10T00:43:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/9dcf2386cb875b234353b93ec43e40219e14900e046bf6ac118f94b1e353/yarl-1.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a979218c1fdb4246a05efc2cc23859d47c89af463a90b99b7c56094daf25a16", size = 365429, upload-time = "2025-06-10T00:43:53.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b2/33a8750f6a4bc224242a635f5f2cff6d6ad5ba651f6edcccf721992c21a0/yarl-1.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255b468adf57b4a7b65d8aad5b5138dce6a0752c139965711bdcb81bc370e1b6", size = 363862, upload-time = "2025-06-10T00:43:55.766Z" },
+    { url = "https://files.pythonhosted.org/packages/98/28/3ab7acc5b51f4434b181b0cee8f1f4b77a65919700a355fb3617f9488874/yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd", size = 355616, upload-time = "2025-06-10T00:43:58.056Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f666894aa947a371724ec7cd2e5daa78ee8a777b21509b4252dd7bd15e29/yarl-1.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8570d998db4ddbfb9a590b185a0a33dbf8aafb831d07a5257b4ec9948df9cb0a", size = 339954, upload-time = "2025-06-10T00:43:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/81/5f466427e09773c04219d3450d7a1256138a010b6c9f0af2d48565e9ad13/yarl-1.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:97c75596019baae7c71ccf1d8cc4738bc08134060d0adfcbe5642f778d1dca38", size = 365575, upload-time = "2025-06-10T00:44:02.051Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e3/e4b0ad8403e97e6c9972dd587388940a032f030ebec196ab81a3b8e94d31/yarl-1.20.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c48912653e63aef91ff988c5432832692ac5a1d8f0fb8a33091520b5bbe19ef", size = 365061, upload-time = "2025-06-10T00:44:04.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/99/b8a142e79eb86c926f9f06452eb13ecb1bb5713bd01dc0038faf5452e544/yarl-1.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c3ae28f3ae1563c50f3d37f064ddb1511ecc1d5584e88c6b7c63cf7702a6d5f", size = 364142, upload-time = "2025-06-10T00:44:06.527Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f2/08ed34a4a506d82a1a3e5bab99ccd930a040f9b6449e9fd050320e45845c/yarl-1.20.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e9642f27036283550f5f57dc6156c51084b458570b9d0d96100c8bebb186a8", size = 381894, upload-time = "2025-06-10T00:44:08.379Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f8/9a3fbf0968eac704f681726eff595dce9b49c8a25cd92bf83df209668285/yarl-1.20.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c26b0c49220d5799f7b22c6838409ee9bc58ee5c95361a4d7831f03cc225b5a", size = 383378, upload-time = "2025-06-10T00:44:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/af/85/9363f77bdfa1e4d690957cd39d192c4cacd1c58965df0470a4905253b54f/yarl-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564ab3d517e3d01c408c67f2e5247aad4019dcf1969982aba3974b4093279004", size = 374069, upload-time = "2025-06-10T00:44:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/35/99/9918c8739ba271dcd935400cff8b32e3cd319eaf02fcd023d5dcd487a7c8/yarl-1.20.1-cp312-cp312-win32.whl", hash = "sha256:daea0d313868da1cf2fac6b2d3a25c6e3a9e879483244be38c8e6a41f1d876a5", size = 81249, upload-time = "2025-06-10T00:44:14.731Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/83/5d9092950565481b413b31a23e75dd3418ff0a277d6e0abf3729d4d1ce25/yarl-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:48ea7d7f9be0487339828a4de0360d7ce0efc06524a48e1810f945c45b813698", size = 86710, upload-time = "2025-06-10T00:44:16.716Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -604,6 +604,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1287,6 +1296,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1398,6 +1416,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
 name = "pylate"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,6 +1445,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/46/67de1d7a65412aa1c896e6b280829b70b57d203fadae6859b690006b8e0a/pypdf-5.6.0.tar.gz", hash = "sha256:a4b6538b77fc796622000db7127e4e58039ec5e6afd292f8e9bf42e2e985a749", size = 5023749, upload-time = "2025-06-01T12:19:40.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/8b/dc3a72d98c22be7a4cbd664ad14c5a3e6295c2dbdf572865ed61e24b5e38/pypdf-5.6.0-py3-none-any.whl", hash = "sha256:ca6bf446bfb0a2d8d71d6d6bb860798d864c36a29b3d9ae8d7fc7958c59f88e7", size = 304208, upload-time = "2025-06-01T12:19:38.003Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]
@@ -1479,6 +1522,7 @@ dependencies = [
     { name = "llama-index" },
     { name = "onnx" },
     { name = "psutil" },
+    { name = "pytest" },
     { name = "sentence-transformers" },
     { name = "setuptools" },
     { name = "srsly" },
@@ -1491,6 +1535,7 @@ all = [
     { name = "batched" },
     { name = "fastapi" },
     { name = "llama-index" },
+    { name = "pytest" },
     { name = "rerankers" },
     { name = "uvicorn" },
     { name = "voyager" },
@@ -1498,6 +1543,7 @@ all = [
 api = [
     { name = "batched" },
     { name = "fastapi" },
+    { name = "pytest" },
     { name = "uvicorn" },
 ]
 train = [
@@ -1521,6 +1567,9 @@ requires-dist = [
     { name = "onnx" },
     { name = "psutil" },
     { name = "pylate", marker = "extra == 'train'" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest", marker = "extra == 'all'" },
+    { name = "pytest", marker = "extra == 'api'" },
     { name = "rerankers", marker = "extra == 'all'" },
     { name = "rerankers", marker = "extra == 'train'" },
     { name = "sentence-transformers" },


### PR DESCRIPTION
This PR refactors the RAG objects to make it so the relationship between model and index is not 1:1 but 1:n (so one model for many indices). This is necessary when serving a RAG server segmented by customer or document type or whatever, and so the model is only loaded once in memory and it keeps switching between indices instead of being loaded once per index.