### PR TITLE
Fix: Update import paths for BaseDocumentCompressor to langchain_core.documents.compressor

### DIFF
--- a/ragatouille/RAGPretrainedModel.py
+++ b/ragatouille/RAGPretrainedModel.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
-from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
+from langchain_core.documents.compressor import BaseDocumentCompressor
 from langchain_core.retrievers import BaseRetriever
 
 from ragatouille.data.corpus_processor import CorpusProcessor

--- a/ragatouille/integrations/_langchain.py
+++ b/ragatouille/integrations/_langchain.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional, Sequence
 
-from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
+from langchain_core.documents.compressor import BaseDocumentCompressor
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever


### PR DESCRIPTION
Updated the import paths for BaseDocumentCompressor in RAGPretrainedModel.py and _langchain.py to reflect the correct module path: langchain_core.documents.compressor.

