### PR TITLE
fix: write ColBERT training TSV exports as UTF-8

### DIFF
--- a/ragatouille/data/training_data_processor.py
+++ b/ragatouille/data/training_data_processor.py
@@ -262,11 +262,11 @@ class TrainingDataProcessor:
         # Create the directory if it does not exist
         os.makedirs(path, exist_ok=True)
 
-        with open(path / "queries.train.colbert.tsv", "w") as f:
+        with open(path / "queries.train.colbert.tsv", "w", encoding="utf-8") as f:
             for query, idx in self.query_map.items():
                 query = query.replace("\t", " ").replace("\n", " ")
                 f.write(f"{idx}\t{query}\n")
-        with open(path / "corpus.train.colbert.tsv", "w") as f:
+        with open(path / "corpus.train.colbert.tsv", "w", encoding="utf-8") as f:
             for document, idx in self.passage_map.items():
                 document = document.replace("\t", " ").replace("\n", " ")
                 f.write(f"{idx}\t{document}\n")

--- a/tests/test_training_data_processor.py
+++ b/tests/test_training_data_processor.py
@@ -34,3 +34,19 @@ def test_process_raw_data_with_miner(collection, queries):
     processor.process_raw_data(raw_data=[], data_type="pairs", data_dir="./")
 
     processor._process_raw_pairs.assert_called_once()
+
+
+def test_export_training_data_writes_utf8(tmp_path, collection, queries):
+    """Non-ASCII text must survive export on Windows (cp1252) locales (#268)."""
+    processor = TrainingDataProcessor(collection, queries, None)
+    processor.query_map = {"Merhaba ıüöğç": 0}
+    processor.passage_map = {"İstanbul ğ": 0}
+    processor.training_triplets = []
+
+    processor.export_training_data(tmp_path)
+
+    queries_tsv = (tmp_path / "queries.train.colbert.tsv").read_text(encoding="utf-8")
+    corpus_tsv = (tmp_path / "corpus.train.colbert.tsv").read_text(encoding="utf-8")
+    assert "Merhaba ıüöğç" in queries_tsv
+    assert "İstanbul ğ" in corpus_tsv
+


### PR DESCRIPTION
## Summary
`TrainingDataProcessor.export_training_data` opened the ColBERT training TSV files with the platform default encoding. On Windows that is often `cp1252`, which raises `UnicodeEncodeError` for characters such as Turkish `ı` (`\u0131`) during `trainer.prepare_training_data()`.

## Change
- Open `queries.train.colbert.tsv` and `corpus.train.colbert.tsv` with `encoding="utf-8"`.
- Add a unit test that exports non-ASCII text and reads it back as UTF-8.

## Test plan
- [x] Unit test `test_export_training_data_writes_utf8` (no network)
- [x] Confirmed both `open(...)` call sites pass `encoding="utf-8"`

Fixes #268
